### PR TITLE
feat(blender): Bump version to blender 2.90

### DIFF
--- a/addon/i3dio/__init__.py
+++ b/addon/i3dio/__init__.py
@@ -36,7 +36,7 @@ bl_info = {
     "description": "Exports blender projects into GIANTS I3D format for use in Giants Engine based games such as "
                    "Farming Simulator",
     "version": (0, 0, 0),  # Always (0, 0, 0) since versioning is controlled by the CI
-    "blender": (2, 83, 0),
+    "blender": (2, 90, 0),
     "location": "File > Import-Export",
     "warning": "First Unofficial Alpha Version",
     "support": "COMMUNITY",


### PR DESCRIPTION
All development on the addon will be using blender 2.90 from now on. Backwards compatability with 2.83 is not guaranteed.

BREAKING CHANGE: The version number has been changed. Please upgrade your blender to 2.90