### PR TITLE
Add property for occluder and lodDistance

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -27,6 +27,8 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
         'non_renderable': {'name': 'nonRenderable', 'default': False},
+        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
+        'is_occluder': {'name': 'occluder', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
         'decal_layer': {'name': 'decalLayer', 'default': 0},
@@ -50,6 +52,18 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         name="Non Renderable",
         description="Don't render the mesh, used for collision boxes etc.",
         default=i3d_map['non_renderable']['default']
+    )
+
+    is_occluder: BoolProperty(
+        name="Occluder",
+        description="Is Occluder?",
+        default=i3d_map['is_occluder']['default']
+    )
+    lod_distance: StringProperty(
+        name="LOD Distance",
+        description="For example:0 100",
+        default=i3d_map['lod_distance']['default'],
+        maxlen=1024
     )
 
     distance_blending: BoolProperty(
@@ -106,6 +120,8 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "receive_shadows")
         layout.prop(obj.i3d_attributes, "non_renderable")
         layout.prop(obj.i3d_attributes, "distance_blending")
+        layout.prop(obj.i3d_attributes, "is_occluder")
+        layout.prop(obj.i3d_attributes, "lod_distance")
         layout.prop(obj.i3d_attributes, "cpu_mesh")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -26,8 +26,7 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
     i3d_map = {
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
-        'non_renderable': {'name': 'nonRenderable', 'default': False},
-        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
+        'non_renderable': {'name': 'nonRenderable', 'default': False},        
         'is_occluder': {'name': 'occluder', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
@@ -58,12 +57,6 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         name="Occluder",
         description="Is Occluder?",
         default=i3d_map['is_occluder']['default']
-    )
-    lod_distance: StringProperty(
-        name="LOD Distance",
-        description="For example:0 100",
-        default=i3d_map['lod_distance']['default'],
-        maxlen=1024
     )
 
     distance_blending: BoolProperty(
@@ -121,7 +114,6 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "non_renderable")
         layout.prop(obj.i3d_attributes, "distance_blending")
         layout.prop(obj.i3d_attributes, "is_occluder")
-        layout.prop(obj.i3d_attributes, "lod_distance")
         layout.prop(obj.i3d_attributes, "cpu_mesh")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -34,6 +34,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'min_clip_distance': {'name': 'minClipDistance', 'default': 0.0},
         'object_mask': {'name': 'objectMask', 'default': '0', 'type': 'HEX'},
         'rigid_body_type': {'default': 'none'},
+        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
         'collision': {'name': 'collision', 'default': True},
         'collision_mask': {'name': 'collisionMask', 'default': 'ff', 'type': 'HEX'},
         'compound': {'name': 'compound', 'default': False},
@@ -51,6 +52,13 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Can be found at: Object Properties -> Visibility -> Renders "
                     "(can also be toggled through outliner)",
         default=True
+    )
+
+    lod_distance: StringProperty(
+        name="LOD Distance",
+        description="For example:0 100",
+        default=i3d_map['lod_distance']['default'],
+        maxlen=1024
     )
 
     clip_distance: FloatProperty(
@@ -117,6 +125,8 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
     )
 
 
+
+
 @register
 class I3D_IO_PT_object_attributes(Panel):
     bl_space_type = 'PROPERTIES'
@@ -133,11 +143,11 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         obj = bpy.context.active_object
-
+        
         i3d_property(layout, obj.i3d_attributes, 'visibility', obj)
         i3d_property(layout, obj.i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, obj.i3d_attributes, 'min_clip_distance', obj)
-
+        i3d_property(layout, obj.i3d_attributes, 'lod_distance', obj)
 
 @register
 class I3D_IO_PT_rigid_body_attributes(Panel):
@@ -145,7 +155,7 @@ class I3D_IO_PT_rigid_body_attributes(Panel):
     bl_region_type = 'WINDOW'
     bl_label = 'Rigidbody'
     bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
+    
 
     @classmethod
     def poll(cls, context):

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -155,7 +155,7 @@ class I3D_IO_PT_rigid_body_attributes(Panel):
     bl_region_type = 'WINDOW'
     bl_label = 'Rigidbody'
     bl_context = 'object'
-    
+    bl_parent_id = 'I3D_IO_PT_object_attributes'
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
Two new features in FS22 for placables are the occluder and the lodDistance property for nodes.

Since they are not applicable in GE (yet) and can therefor only be added manually, this pull requests adds the Options for both Properties.

Since the exporter is setup to only export values which are changes, the default value for lod_distance should only be exported once an actual value is setup (like `0 100`)