### PR TITLE
Update material.py for blender 3.3.0

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -56,7 +56,15 @@ class Material(Node):
         gloss_node = self.blender_material.node_tree.nodes.get('Glossmap')
         if gloss_node is not None:
             try:
-                gloss_image_path = gloss_node.inputs['Image'].links[0].from_node.image.filepath
+                if bpy.app.version < (3, 3, 0):
+                    gloss_image_path = gloss_node.inputs['Image'].links[0].from_node.image.filepath
+                else:
+                    if gloss_node.type == "SEPARATE_COLOR":
+                        gloss_image_path = gloss_node.inputs['Color'].links[0].from_node.image.filepath
+                    elif gloss_node.type == "TEX_IMAGE":
+                        gloss_image_path = gloss_node.image.filepath
+                    else:
+                        raise AttributeError(f"Has an improperly setup Glossmap")
             except (AttributeError, IndexError, KeyError):
                 self.logger.exception(f"Has an improperly setup Glossmap")
             else:


### PR DESCRIPTION
The name of the "Separate RGB" input has changed from `Image` to `Color` in blender 3.3.0.  Also support just using an image named "Glossmap" instead.

This change is protected by a blender version check.

The "old way" that still works - using the newly renamed node "Separate Color", manually re-named to "Glossmap"

![2022-09-13 10_17_16-Blender_  C__Users_jtsag_Desktop_test blend](https://user-images.githubusercontent.com/605986/189926493-c3e5b53d-f218-477b-a823-1ee8a1085a78.png)

An optional "new way" - using just an Image Texture manually re-named to "Glossmap"

![2022-09-13 10_11_25-Blender](https://user-images.githubusercontent.com/605986/189926808-4262cd39-113a-4b6a-bc32-2c20001617fa.png)

I've not delved deeply into 3.3 yet, but other than this, it all *seems* to be working correctly - only re-ran a couple quick exports to see if they appeared the same.  Fwiw, been on 3.2 for a week or two prior to this, no issues found there.