### PR TITLE
Feature: Option to export Bounding Volumes

### DIFF
--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -122,8 +122,6 @@ class SceneGraphNode(Node):
         return f"{self.name}"
 
     def _write_properties(self):
-        # Implementation for Bounding Volumes requires calculation best here since we only need the data for export
-        utility.update_bv_data(self.blender_object)
         # Write general node properties (Transform properties in Giants Engine)
         try:
             xml_i3d.write_i3d_properties(self.blender_object, self.blender_object.i3d_attributes, self.xml_elements)

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -122,6 +122,8 @@ class SceneGraphNode(Node):
         return f"{self.name}"
 
     def _write_properties(self):
+        # Implementation for Bounding Volumes requires calculation best here since we only need the data for export
+        utility.update_bv_data(self.blender_object)
         # Write general node properties (Transform properties in Giants Engine)
         try:
             xml_i3d.write_i3d_properties(self.blender_object, self.blender_object.i3d_attributes, self.xml_elements)

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -7,7 +7,7 @@ import bpy
 
 from .node import (Node, SceneGraphNode)
 
-from .. import (debugging, xml_i3d)
+from .. import (debugging, utility, xml_i3d)
 from ..i3d import I3D
 
 
@@ -432,3 +432,7 @@ class ShapeNode(SceneGraphNode):
         self._write_attribute('shapeId', self.shape_id)
         self._write_attribute('materialIds', self.i3d.shapes[self.shape_id].material_indexes)
         super().populate_xml_element()
+
+    def _write_properties(self):
+        utility.update_bv_data(self.blender_object)
+        super()._write_properties()

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -27,6 +27,8 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
         'non_renderable': {'name': 'nonRenderable', 'default': False},
+        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
+        'is_occluder': {'name': 'occluder', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
         'decal_layer': {'name': 'decalLayer', 'default': 0},
@@ -50,6 +52,18 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         name="Non Renderable",
         description="Don't render the mesh, used for collision boxes etc.",
         default=i3d_map['non_renderable']['default']
+    )
+
+    is_occluder: BoolProperty(
+        name="Occluder",
+        description="Is Occluder?",
+        default=i3d_map['is_occluder']['default']
+    )
+    lod_distance: StringProperty(
+        name="LOD Distance",
+        description="For example:0 100",
+        default=i3d_map['lod_distance']['default'],
+        maxlen=1024
     )
 
     distance_blending: BoolProperty(
@@ -106,6 +120,8 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "receive_shadows")
         layout.prop(obj.i3d_attributes, "non_renderable")
         layout.prop(obj.i3d_attributes, "distance_blending")
+        layout.prop(obj.i3d_attributes, "is_occluder")
+        layout.prop(obj.i3d_attributes, "lod_distance")
         layout.prop(obj.i3d_attributes, "cpu_mesh")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -26,8 +26,7 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
     i3d_map = {
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
-        'non_renderable': {'name': 'nonRenderable', 'default': False},
-        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
+        'non_renderable': {'name': 'nonRenderable', 'default': False},        
         'is_occluder': {'name': 'occluder', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
@@ -58,12 +57,6 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         name="Occluder",
         description="Is Occluder?",
         default=i3d_map['is_occluder']['default']
-    )
-    lod_distance: StringProperty(
-        name="LOD Distance",
-        description="For example:0 100",
-        default=i3d_map['lod_distance']['default'],
-        maxlen=1024
     )
 
     distance_blending: BoolProperty(
@@ -121,7 +114,6 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "non_renderable")
         layout.prop(obj.i3d_attributes, "distance_blending")
         layout.prop(obj.i3d_attributes, "is_occluder")
-        layout.prop(obj.i3d_attributes, "lod_distance")
         layout.prop(obj.i3d_attributes, "cpu_mesh")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -174,19 +174,8 @@ class I3D_IO_PT_shape_bounding_box(Panel):
         row.prop(obj.i3d_attributes, 'bounding_volume_object')     
 
         row = layout.row()
-        layout.label(text="Both Center and Radius will be calculated when exporting automatically.")
-        
-        row = layout.row()
-        row.prop(obj.i3d_attributes, 'bv_center')
-        row.enabled = False
+        layout.label(text="Both Center and Radius will be calculated automatically when exporting.")        
 
-        row = layout.row()
-        row.prop(obj.i3d_attributes, 'bv_radius')   
-        row.enabled = False
-
-        #row = layout.row()
-        #row.operator('object.i3d_update_bounding_voulume', text="Update Values")
-       
         if obj.i3d_attributes.bounding_volume_object is None:
             obj.i3d_attributes.property_unset('bv_center')
             obj.i3d_attributes.property_unset('bv_radius')

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -27,7 +27,7 @@ def register(cls):
 @register
 class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
     i3d_map = {
-        'visibility': {'name': 'Visibility', 'default': True, 'tracking': {'member_path': 'hide_render',
+        'visibility': {'name': 'visibility', 'default': True, 'tracking': {'member_path': 'hide_render',
                                                                            'mapping': {True: False,
                                                                                        False: True}}},
         'clip_distance': {'name': 'clipDistance', 'default': 1000000.0},

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -34,6 +34,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'min_clip_distance': {'name': 'minClipDistance', 'default': 0.0},
         'object_mask': {'name': 'objectMask', 'default': '0', 'type': 'HEX'},
         'rigid_body_type': {'default': 'none'},
+        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
         'collision': {'name': 'collision', 'default': True},
         'collision_mask': {'name': 'collisionMask', 'default': 'ff', 'type': 'HEX'},
         'compound': {'name': 'compound', 'default': False},
@@ -51,6 +52,13 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Can be found at: Object Properties -> Visibility -> Renders "
                     "(can also be toggled through outliner)",
         default=True
+    )
+
+    lod_distance: StringProperty(
+        name="LOD Distance",
+        description="For example:0 100",
+        default=i3d_map['lod_distance']['default'],
+        maxlen=1024
     )
 
     clip_distance: FloatProperty(
@@ -117,6 +125,8 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
     )
 
 
+
+
 @register
 class I3D_IO_PT_object_attributes(Panel):
     bl_space_type = 'PROPERTIES'
@@ -133,11 +143,11 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         obj = bpy.context.active_object
-
+        
         i3d_property(layout, obj.i3d_attributes, 'visibility', obj)
         i3d_property(layout, obj.i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, obj.i3d_attributes, 'min_clip_distance', obj)
-
+        i3d_property(layout, obj.i3d_attributes, 'lod_distance', obj)
 
 @register
 class I3D_IO_PT_rigid_body_attributes(Panel):
@@ -145,7 +155,7 @@ class I3D_IO_PT_rigid_body_attributes(Panel):
     bl_region_type = 'WINDOW'
     bl_label = 'Rigidbody'
     bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
+    
 
     @classmethod
     def poll(cls, context):

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -39,6 +39,13 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'collision_mask': {'name': 'collisionMask', 'default': 'ff', 'type': 'HEX'},
         'compound': {'name': 'compound', 'default': False},
         'trigger': {'name': 'trigger', 'default': False},
+        'use_parent': {'name': 'useParent', 'default': True},
+        'minute_of_day_start': {'name': 'minuteOfDayStart', 'default': 0},
+        'minute_of_day_end': {'name': 'minuteOfDayEnd', 'default': 0},
+        'day_of_year_start': {'name': 'dayOfYearStart', 'default': 0},
+        'day_of_year_end': {'name': 'dayOfYearEnd', 'default': 0},
+        'weather_required_mask': {'name': 'weatherRequiredMask', 'default': '0', 'type': 'HEX'},
+        'weather_prevent_mask': {'name': 'weatherPreventMask', 'default': '0', 'type': 'HEX'},
     }
 
     visibility: BoolProperty(
@@ -124,7 +131,63 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         default=i3d_map['trigger']['default']
     )
 
+    use_parent: BoolProperty(
+        name="Use Parent",
+        description="Can be found at: Attributes -> Visibility Condition",
+        default=True
+    )
 
+    minute_of_day_start: IntProperty(
+        name="Minute of Day Start",
+        description="The minute of day when visibility is true. "
+                    "8:00 AM = 480 / "
+                    "8:00 PM = 1200",
+        default=i3d_map['minute_of_day_start']['default'],
+        max=1440,
+        min=0,
+    )
+
+    minute_of_day_end: IntProperty(
+        name="Minute of Day End",
+        description="The minute of day when visibility is false. "
+                    "8:00 AM = 480 / "
+                    "8:00 PM = 1200",
+        default=i3d_map['minute_of_day_end']['default'],
+        max=1440,
+        min=0,
+    )
+
+    day_of_year_start: IntProperty(
+        name="Day of Year Start",
+        description="Day of Year when visibility is true.",
+        default=i3d_map['day_of_year_start']['default'],
+        max=365,
+        min=0,
+    )
+
+    day_of_year_end: IntProperty(
+        name="Day of Year End",
+        description="Day of Year when visibility is false.",
+        default=i3d_map['day_of_year_end']['default'],
+        max=365,
+        min=0,
+    )
+
+    weather_required_mask: StringProperty(
+        name="Weather Required Mask (Hex)",
+        description="The weather required mask as a hexadecimal value. "
+                    "Winter = 400 / "
+                    "Winter + Snow = 408",
+        default=i3d_map['weather_required_mask']['default']
+    )
+
+    weather_prevent_mask: StringProperty(
+        name="Weather Prevent Mask (Hex)",
+        description="The weather prevent mask as a hexadecimal value. "
+                    "Summer = 100 / "
+                    "Summer + Sun = 101",
+        default=i3d_map['weather_prevent_mask']['default']
+    )
 
 
 @register
@@ -192,6 +255,65 @@ class I3D_IO_PT_rigid_body_attributes(Panel):
             obj.i3d_attributes.property_unset('collision')
             obj.i3d_attributes.property_unset('collision_mask')
             obj.i3d_attributes.property_unset('trigger')
+
+@register
+class I3D_IO_PT_visibility_condition_attributes(Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_label = 'Visibility Condition'
+    bl_context = 'object'
+    bl_parent_id = 'I3D_IO_PT_object_attributes'
+
+    @classmethod
+    def poll(cls, context):
+        return context.object is not None and context.object.type == 'MESH'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        obj = bpy.context.active_object
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'use_parent')
+        
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'minute_of_day_start')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'minute_of_day_end')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'day_of_year_start')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'day_of_year_end')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'weather_required_mask')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+        row = layout.row()
+        row.prop(obj.i3d_attributes, 'weather_prevent_mask')
+        if obj.i3d_attributes.use_parent == True:
+            row.enabled = False
+
+        if obj.i3d_attributes.use_parent == True:
+            obj.i3d_attributes.property_unset('minute_of_day_start')
+            obj.i3d_attributes.property_unset('minute_of_day_end')
+            obj.i3d_attributes.property_unset('day_of_year_start')
+            obj.i3d_attributes.property_unset('day_of_year_end')
+            obj.i3d_attributes.property_unset('weather_required_mask')
+            obj.i3d_attributes.property_unset('weather_prevent_mask')
 
 
 @register

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -11,7 +11,6 @@ from bpy.props import (
     FloatProperty,
     IntProperty,
     CollectionProperty,
-    FloatVectorProperty,
 )
 
 from .helper_functions import i3d_property
@@ -47,8 +46,6 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'day_of_year_end': {'name': 'dayOfYearEnd', 'default': 0},
         'weather_required_mask': {'name': 'weatherRequiredMask', 'default': '0', 'type': 'HEX'},
         'weather_prevent_mask': {'name': 'weatherPreventMask', 'default': '0', 'type': 'HEX'},
-        'bv_center': {'name': 'bv_center', 'default': (0,0,0)},
-        'bv_radius': {'name': 'bv_radius', 'default': 0},
     }
 
     visibility: BoolProperty(
@@ -190,29 +187,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
                     "Summer = 100 / "
                     "Summer + Sun = 101",
         default=i3d_map['weather_prevent_mask']['default']
-    )
-
-
-    bv_center: FloatVectorProperty(
-        name="Bounding Volume Center",
-        description="Center of the Bounding Volume",
-        default=i3d_map['bv_center']['default'],
-        min=-i3d_max,
-        max=i3d_max,
-        soft_min=-65535.0,
-        soft_max=65535.0,
-        size=3
-    )
-
-    bv_radius: FloatProperty(        
-        name="Bounding Volume Radius",
-        description="The radius of the Bounding Volume, or, the biggest dimension",
-        default=i3d_map['bv_radius']['default'],
-        min=0.0,
-        max=i3d_max,
-        soft_min=0,
-        soft_max=65535.0
-    )
+    )    
 
 
 @register
@@ -354,7 +329,6 @@ class I3DMergeGroupObjectData(bpy.types.PropertyGroup):
                              default=''
                              )
 
-
 @register
 class I3D_IO_PT_merge_group_attributes(Panel):
     bl_space_type = 'PROPERTIES'
@@ -381,55 +355,6 @@ class I3D_IO_PT_merge_group_attributes(Panel):
         row = layout.row()
         row.prop(obj.i3d_merge_group, 'group_id')
 
-@register
-class I3DBoundingVolumes(bpy.types.PropertyGroup):
-    bounding_volume_object: PointerProperty(
-        #update=lambda self, context: get_bv_center_and_radius(self, context, bpy.context.active_object),
-        name="Bounding Volume",
-        description="Object used to calculate bvCenter and bvRadius",
-        type=bpy.types.Object
-    )
-
-
-@register
-class I3D_IO_PT_bounding_box(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Bounding Volumes'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'MESH'
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = bpy.context.active_object
-
-        row = layout.row()
-        row.prop(obj.i3d_bounding_volume, 'bounding_volume_object')     
-
-        row = layout.row()
-        layout.label(text="Both Center and Radius will be calculated when exporting automatically.")
-        
-        row = layout.row()
-        row.prop(obj.i3d_attributes, 'bv_center')
-        row.enabled = False
-
-        row = layout.row()
-        row.prop(obj.i3d_attributes, 'bv_radius')   
-        row.enabled = False
-
-        #row = layout.row()
-        #row.operator('object.i3d_update_bounding_voulume', text="Update Values")
-       
-        if obj.i3d_bounding_volume.bounding_volume_object is None:
-            obj.i3d_attributes.property_unset('bv_center')
-            obj.i3d_attributes.property_unset('bv_radius')
-
 
 @register
 class I3DMappingData(bpy.types.PropertyGroup):
@@ -444,7 +369,6 @@ class I3DMappingData(bpy.types.PropertyGroup):
         description="If this is left empty the name of the object itself will be used",
         default=''
     )
-
 
 @register
 class I3D_IO_PT_mapping_attributes(Panel):
@@ -476,14 +400,12 @@ def register():
     bpy.types.Object.i3d_attributes = PointerProperty(type=I3DNodeObjectAttributes)
     bpy.types.Object.i3d_merge_group = PointerProperty(type=I3DMergeGroupObjectData)
     bpy.types.Object.i3d_mapping = PointerProperty(type=I3DMappingData)
-    bpy.types.Object.i3d_bounding_volume = PointerProperty(type=I3DBoundingVolumes)
 
 
 def unregister():
     del bpy.types.Object.i3d_mapping
     del bpy.types.Object.i3d_merge_group
     del bpy.types.Object.i3d_attributes
-    del bpy.types.Object.i3d_bounding_volume
 
     for cls in classes:
         bpy.utils.unregister_class(cls)

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -155,7 +155,7 @@ class I3D_IO_PT_rigid_body_attributes(Panel):
     bl_region_type = 'WINDOW'
     bl_label = 'Rigidbody'
     bl_context = 'object'
-    
+    bl_parent_id = 'I3D_IO_PT_object_attributes'
 
     @classmethod
     def poll(cls, context):

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -88,7 +88,10 @@ def update_bv_data(dataObject: object):
         volumeObject = dataObject.data.i3d_attributes.bounding_volume_object
         bv_center = sum((mathutils.Vector(corner) for corner in volumeObject.bound_box), mathutils.Vector()) / 8
         world_center = volumeObject.matrix_world @ bv_center
-        relative_center = world_center - dataObject.location
+        dataObject_world_matrix = dataObject.matrix_world
+
+        relative_center = world_center - dataObject_world_matrix.to_translation()
+        relative_center = dataObject_world_matrix.to_3x3().inverted() @ relative_center
 
         dataObject.data.i3d_attributes.bv_center = (relative_center.x,relative_center.z,-relative_center.y)
         dataObject.data.i3d_attributes.bv_radius = max(volumeObject.dimensions) / 2

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -82,3 +82,23 @@ def sort_blender_objects_by_name(objects: List[BlenderObject]) -> List[BlenderOb
     sorted_objects = list(objects)  # Create new list from whatever comes in, whether it is an existing list or a tuple
     sorted_objects.sort(key=lambda x: x.name)  # Sort by name
     return sorted_objects
+
+def update_bv_data(dataObject: object):
+    if dataObject.i3d_bounding_volume.bounding_volume_object != None:
+        # Getting Center of Mesh: Answer from https://blender.stackexchange.com/a/62044
+        cursorLoc = bpy.context.scene.cursor.location.copy()
+        bpy.context.scene.cursor.location = dataObject.location
+        bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
+        loc = dataObject.location.copy()
+        bpy.ops.object.origin_set(type='ORIGIN_CURSOR')
+        bpy.context.scene.cursor.location = cursorLoc
+
+        dataObject.i3d_attributes.bv_center = loc
+
+        dimensions = [dataObject.i3d_bounding_volume.bounding_volume_object.dimensions.x,dataObject.i3d_bounding_volume.bounding_volume_object.dimensions.y,dataObject.i3d_bounding_volume.bounding_volume_object.dimensions.z]
+        radius = max(dimensions)
+        
+        if radius > 0:
+            dataObject.i3d_attributes.bv_radius = radius/2
+        else:
+            dataObject.i3d_attributes.bv_radius = 0


### PR DESCRIPTION
As described in this Discussion thread https://github.com/StjerneIdioten/I3D-Blender-Addon/discussions/135 the exporter can now export meshes as Bounding Volumes.

You can select via Object Picker an Object that serves as the Bounding Volume. When exporting, the exporter will automatically calculate the bv_center and bc_radius values. For the values it uses the largest dimension of the object divided by two (to make sure that even box-type bounding volumes could be used)

Here is a picture of the UI:
![2023-04-08 17_10_47-Blender  C__Users_ssnd2_Desktop_BoundingBox_BoundingBox blend](https://user-images.githubusercontent.com/3914410/230728763-31c6c4d5-2b06-4ec5-85de-4a8b3f6539a8.jpg)

Here is a test scene.
[BoundingBox.zip](https://github.com/StjerneIdioten/I3D-Blender-Addon/files/11183549/BoundingBox.zip)