### PR TITLE
Feature: Adds more functionality to the merge group panel

### DIFF
--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -31,6 +31,11 @@ def register(cls):
 
 
 @register
+class I3DMergeGroupItems(bpy.types.PropertyGroup):
+    name: StringProperty()
+
+
+@register
 class I3DExportUIProperties(bpy.types.PropertyGroup):
     selection: EnumProperty(
         name="Export",
@@ -158,6 +163,8 @@ class I3DExportUIProperties(bpy.types.PropertyGroup):
         ),
         default='CLEAN'
     )
+
+    mg_items: bpy.props.CollectionProperty(type=I3DMergeGroupItems)
 
 
 @register

--- a/addon/i3dio/ui/helper_functions.py
+++ b/addon/i3dio/ui/helper_functions.py
@@ -92,6 +92,20 @@ def i3d_property(layout, attributes, attribute: str, obj):
         attrib_row.prop(attributes, attribute)
 
 
+def update_group_id(self, context):
+    self.group_id = self.group_list
+
+
+def get_group_id_list(self, context):
+    group_ids = set()
+
+    for obj in context.scene.objects:
+        if obj.type == 'MESH' and obj.i3d_merge_group.group_id != '':
+            group_ids.add(obj.i3d_merge_group.group_id)
+
+    return [(group_id, group_id, "") for group_id in group_ids]
+
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)

--- a/addon/i3dio/ui/helper_functions.py
+++ b/addon/i3dio/ui/helper_functions.py
@@ -93,17 +93,16 @@ def i3d_property(layout, attributes, attribute: str, obj):
 
 
 def update_group_id(self, context):
-    self.group_id = self.group_list
+    """ Updates custom_mg list with new item if it's not already in the list """
+    if self.group_id:
+        # Check if the group id is not in the custom_mg list
+        group_id_not_in_list = self.group_id not in (item.value for item in context.scene.custom_mg)
 
-
-def get_group_id_list(self, context):
-    group_ids = set()
-
-    for obj in context.scene.objects:
-        if obj.type == 'MESH' and obj.i3d_merge_group.group_id != '':
-            group_ids.add(obj.i3d_merge_group.group_id)
-
-    return [(group_id, group_id, "") for group_id in group_ids]
+        # If group id is not in the list, add it
+        if group_id_not_in_list:
+            item = context.scene.custom_mg.add()
+            item.value = self.group_id
+            self.group_list = item.value
 
 
 def register():

--- a/addon/i3dio/ui/helper_functions.py
+++ b/addon/i3dio/ui/helper_functions.py
@@ -92,19 +92,6 @@ def i3d_property(layout, attributes, attribute: str, obj):
         attrib_row.prop(attributes, attribute)
 
 
-def update_group_id(self, context):
-    """ Updates custom_mg list with new item if it's not already in the list """
-    if self.group_id:
-        # Check if the group id is not in the custom_mg list
-        group_id_not_in_list = self.group_id not in (item.value for item in context.scene.custom_mg)
-
-        # If group id is not in the list, add it
-        if group_id_not_in_list:
-            item = context.scene.custom_mg.add()
-            item.value = self.group_id
-            self.group_list = item.value
-
-
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -13,7 +13,7 @@ from bpy.props import (
     CollectionProperty,
 )
 
-from .helper_functions import i3d_property
+from .helper_functions import i3d_property, update_group_id, get_group_id_list
 from ..xml_i3d import i3d_max
 
 classes = []
@@ -329,6 +329,27 @@ class I3DMergeGroupObjectData(bpy.types.PropertyGroup):
                              default=''
                              )
 
+    group_list: EnumProperty(name='',
+                             description='List of merge groups available in the scene',
+                             items=get_group_id_list,
+                             update=update_group_id
+                             )
+
+
+@register
+class I3D_IO_OT_select_mg_objects(bpy.types.Operator):
+    bl_idname = "i3dio.select_mg_objects"
+    bl_label = "Select Objects in MG"
+    bl_description = "Select all objects in the same merge group"
+
+    group_id: bpy.props.StringProperty()
+
+    def execute(self, context):
+        for obj in context.scene.objects:
+            if obj.i3d_merge_group.group_id == self.group_id:
+                obj.select_set(True)
+        return {'FINISHED'}
+
 
 @register
 class I3D_IO_PT_merge_group_attributes(Panel):
@@ -355,6 +376,13 @@ class I3D_IO_PT_merge_group_attributes(Panel):
 
         row = layout.row()
         row.prop(obj.i3d_merge_group, 'group_id')
+        row.prop(obj.i3d_merge_group, 'group_list')
+
+        row = layout.row()
+        select_op = row.operator("i3dio.select_mg_objects", text="Select Objects in same MG")
+        select_op.group_id = obj.i3d_merge_group.group_id
+        if obj.i3d_merge_group.group_id == '':
+            row.enabled = False
 
 
 @register


### PR DESCRIPTION
PR to solve request in #79

You get a list with all the merge groups you have added
![image](https://user-images.githubusercontent.com/57712777/234971131-e723a7d0-af59-4414-bfa6-f6625c99768c.png)

How to add merge groups to the list:
Write your prefered merge group name in the string property as you did before
Click on the + symbol (this will be available to click on if the name doesn't already exist in the list)
Now you can access the merge group in the list with all your mesh objects


Select all objects with same assigned merge group
![image](https://user-images.githubusercontent.com/57712777/234971830-ff1b9c14-2365-4448-8375-2ac4a7437078.png)
