### PR TITLE
fix(material): Fix problem with emissive tex & diffuseColor

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -117,7 +117,9 @@ class Material(Node):
                     self.xml_elements['Texture'] = xml_i3d.SubElement(self.element, 'Texture')
                     self._write_attribute('fileId', file_id, 'Texture')
         # Write the diffuse colors
-        self._write_diffuse(diffuse)
+        r, g, b, _ = diffuse
+        if (r, g, b) != (0, 0, 0):
+            self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
         emission_socket = node.inputs['Emission']
@@ -173,6 +175,7 @@ class Material(Node):
             if shader_settings.source.endswith("mirrorShader.xml"):
                 params = {'type': 'planar', 'refractiveIndex': '10', 'bumpScale': '0.1'}
                 xml_i3d.SubElement(self.element, 'Reflectionmap', params)
+                self._write_diffuse((0, 0, 0, 1))
 
             if shader_settings.variation != shader_picker.shader_no_variation:
                 self._write_attribute('customShaderVariation', shader_settings.variation)


### PR DESCRIPTION
Should solve issue #173 

Decided to go with this to solve the problem:
If RGB = 0 0 0 it won't write the diffuseColor

There is nothing that use diffuse color 0 0 0 except for mirrors.
So I added write diffuse function inside the mirrorShader if statement in _emissive_from_nodes function with hardcoded 0 0 0 1 diffuseColor (which is what the mirror material always should have)