### PR TITLE
Fix shader node inputs for Blender 4.0

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -165,8 +165,8 @@ class Material(Node):
         r, g, b, a = emission_c
 
         if blender_version >= 4:
-            has_emission = node.inputs['Emission Strength'].default_value == 1.0
-            if has_emission:
+            has_emission = node.inputs['Emission Strength'].default_value == 0.0
+            if not has_emission:
                 self.logger.debug("Write emissiveColor")
                 self._write_emission(emission_c)
         else:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -135,14 +135,7 @@ class Material(Node):
                 self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
-        blender_version = utility.blender_version()
-        # Blender 4.0 have different input names
-        if blender_version >= 4:
-            emission_input = 'Emission Color'
-        else:
-            emission_input = 'Emission'
-
-        emission_socket = node.inputs[emission_input]
+        emission_socket = node.inputs['Emission color' if bpy.app.version >= (4, 0, 0) else 'Emission']
         emission_c = emission_socket.default_value
         emissive_path = None
         if emission_socket.is_linked:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -169,8 +169,8 @@ class Material(Node):
             if not has_emission:
                 self.logger.debug("Write emissiveColor")
                 self._write_emission(emission_c)
-        else:
-            if (0, 0, 0, 1) != (r, g, b, a):
+        elif (0, 0, 0, 1) != (r, g, b, a):
+
                 self.logger.debug("Write emissiveColor")
                 self._write_emission(emission_c)
 

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -77,7 +77,7 @@ class Material(Node):
 
     def _specular_from_nodes(self, node):
         specular = [1.0 - node.inputs['Roughness'].default_value,
-                    node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value,
+                    node.inputs['Specular IOR Level'].default_value if bpy.app.version >= (4, 0, 0) else node.inputs['Specular'].default_value,
                     node.inputs['Metallic'].default_value]
         self._write_specular(specular)
 
@@ -118,12 +118,12 @@ class Material(Node):
                     self._write_attribute('fileId', file_id, 'Texture')
         else:
             # Write the diffuse colors
-            emission_socket = node.inputs['Emission Color' if bpy.app.version >= (4, 0, 0) else 'Emission']
+            emission_socket = node.inputs['Emission Color'] if bpy.app.version >= (4, 0, 0) else node.inputs['Emission']
             if not emission_socket.is_linked:
                 self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
-        emission_socket = node.inputs['Emission color' if bpy.app.version >= (4, 0, 0) else 'Emission']
+        emission_socket = node.inputs['Emission Color'] if bpy.app.version >= (4, 0, 0) else node.inputs['Emission']
         emission_c = emission_socket.default_value
         emissive_path = None
         if emission_socket.is_linked:
@@ -145,15 +145,14 @@ class Material(Node):
             self.logger.debug("Has no Emissivemap")
         r, g, b, a = emission_c
 
-        if bpy.app.version >= (4, 0, 0)
+        if bpy.app.version >= (4, 0, 0):
             has_emission = node.inputs['Emission Strength'].default_value == 0.0
             if not has_emission:
                 self.logger.debug("Write emissiveColor")
                 self._write_emission(emission_c)
         elif (0, 0, 0, 1) != (r, g, b, a):
-
-                self.logger.debug("Write emissiveColor")
-                self._write_emission(emission_c)
+            self.logger.debug("Write emissiveColor")
+            self._write_emission(emission_c)
 
     def _resolve_without_nodes(self):
         material = self.blender_material

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -76,8 +76,14 @@ class Material(Node):
             self.logger.debug(f"Has no Glossmap")
 
     def _specular_from_nodes(self, node):
+        # Blender 4.0 have different input names
+        if utility.blender_version() >= 4:
+            specular_input = 'Specular IOR Level'
+        else:
+            specular_input = 'Specular'
+
         specular = [1.0 - node.inputs['Roughness'].default_value,
-                    node.inputs['Specular'].default_value,
+                    node.inputs[specular_input].default_value,
                     node.inputs['Metallic'].default_value]
         self._write_specular(specular)
 
@@ -117,13 +123,25 @@ class Material(Node):
                     self.xml_elements['Texture'] = xml_i3d.SubElement(self.element, 'Texture')
                     self._write_attribute('fileId', file_id, 'Texture')
         else:
+            # Blender 4.0 have different input names
+            if utility.blender_version() >= 4:
+                emission_input = 'Emission Color'
+            else:
+                emission_input = 'Emission'
+
             # Write the diffuse colors
-            emission_socket = node.inputs['Emission']
+            emission_socket = node.inputs[emission_input]
             if not emission_socket.is_linked:
                 self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
-        emission_socket = node.inputs['Emission']
+        # Blender 4.0 have different input names
+        if utility.blender_version() >= 4:
+            emission_input = 'Emission Color'
+        else:
+            emission_input = 'Emission'
+
+        emission_socket = node.inputs[emission_input]
         emission_c = emission_socket.default_value
         emissive_path = None
         if emission_socket.is_linked:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -77,7 +77,7 @@ class Material(Node):
 
     def _specular_from_nodes(self, node):
         specular = [1.0 - node.inputs['Roughness'].default_value,
-                    node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value
+                    node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value,
                     node.inputs['Metallic'].default_value]
         self._write_specular(specular)
 

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -83,7 +83,7 @@ class Material(Node):
             specular_input = 'Specular'
 
         specular = [1.0 - node.inputs['Roughness'].default_value,
-                    node.inputs[specular_input].default_value,
+                    node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value
                     node.inputs['Metallic'].default_value]
         self._write_specular(specular)
 

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -130,7 +130,7 @@ class Material(Node):
                 emission_input = 'Emission'
 
             # Write the diffuse colors
-            emission_socket = node.inputs[emission_input]
+            emission_socket = node.inputs['Emission Color' if bpy.app.version >= (4, 0, 0) else 'Emission']
             if not emission_socket.is_linked:
                 self._write_diffuse(diffuse)
 

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -76,12 +76,6 @@ class Material(Node):
             self.logger.debug(f"Has no Glossmap")
 
     def _specular_from_nodes(self, node):
-        # Blender 4.0 have different input names
-        if utility.blender_version() >= 4:
-            specular_input = 'Specular IOR Level'
-        else:
-            specular_input = 'Specular'
-
         specular = [1.0 - node.inputs['Roughness'].default_value,
                     node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value
                     node.inputs['Metallic'].default_value]
@@ -123,12 +117,6 @@ class Material(Node):
                     self.xml_elements['Texture'] = xml_i3d.SubElement(self.element, 'Texture')
                     self._write_attribute('fileId', file_id, 'Texture')
         else:
-            # Blender 4.0 have different input names
-            if utility.blender_version() >= 4:
-                emission_input = 'Emission Color'
-            else:
-                emission_input = 'Emission'
-
             # Write the diffuse colors
             emission_socket = node.inputs['Emission Color' if bpy.app.version >= (4, 0, 0) else 'Emission']
             if not emission_socket.is_linked:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -164,7 +164,7 @@ class Material(Node):
             self.logger.debug("Has no Emissivemap")
         r, g, b, a = emission_c
 
-        if blender_version >= 4:
+        if bpy.app.version >= (4, 0, 0)
             has_emission = node.inputs['Emission Strength'].default_value == 0.0
             if not has_emission:
                 self.logger.debug("Write emissiveColor")

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -135,8 +135,9 @@ class Material(Node):
                 self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
+        blender_version = utility.blender_version()
         # Blender 4.0 have different input names
-        if utility.blender_version() >= 4:
+        if blender_version >= 4:
             emission_input = 'Emission Color'
         else:
             emission_input = 'Emission'
@@ -162,9 +163,16 @@ class Material(Node):
                     return
             self.logger.debug("Has no Emissivemap")
         r, g, b, a = emission_c
-        if (0, 0, 0, 1) != (r, g, b, a):
-            self.logger.debug("Write emissiveColor")
-            self._write_emission(emission_c)
+
+        if blender_version >= 4:
+            has_emission = node.inputs['Emission Strength'].default_value == 1.0
+            if has_emission:
+                self.logger.debug("Write emissiveColor")
+                self._write_emission(emission_c)
+        else:
+            if (0, 0, 0, 1) != (r, g, b, a):
+                self.logger.debug("Write emissiveColor")
+                self._write_emission(emission_c)
 
     def _resolve_without_nodes(self):
         material = self.blender_material

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -77,7 +77,7 @@ class Material(Node):
 
     def _specular_from_nodes(self, node):
         specular = [1.0 - node.inputs['Roughness'].default_value,
-                    node.inputs['Specular IOR Level'].default_value if bpy.app.version >= (4, 0, 0) else node.inputs['Specular'].default_value,
+                    node.inputs['Specular IOR Level' if bpy.app.version >= (4, 0, 0) else 'Specular'].default_value,
                     node.inputs['Metallic'].default_value]
         self._write_specular(specular)
 
@@ -118,12 +118,12 @@ class Material(Node):
                     self._write_attribute('fileId', file_id, 'Texture')
         else:
             # Write the diffuse colors
-            emission_socket = node.inputs['Emission Color'] if bpy.app.version >= (4, 0, 0) else node.inputs['Emission']
+            emission_socket = node.inputs['Emission Color' if bpy.app.version >= (4, 0, 0) else 'Emission']
             if not emission_socket.is_linked:
                 self._write_diffuse(diffuse)
 
     def _emissive_from_nodes(self, node):
-        emission_socket = node.inputs['Emission Color'] if bpy.app.version >= (4, 0, 0) else node.inputs['Emission']
+        emission_socket = node.inputs['Emission Color' if bpy.app.version >= (4, 0, 0) else 'Emission']
         emission_c = emission_socket.default_value
         emissive_path = None
         if emission_socket.is_linked:

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -210,8 +210,9 @@ class IndexedTriangleSet(Node):
                 # Add vertex color
                 vertex_color = None
                 if len(mesh.vertex_colors):
-                    # Get the color from the first layer, since only one vertex color layer is supported in GE
-                    vertex_color = mesh.vertex_colors[0].data[loop_index].color
+                    # Get the color from the active layer or first layer, since only one vertex color layer is supported in GE
+                    color_layer = mesh.vertex_colors.active if mesh.vertex_colors.active is not None else mesh.vertex_colors[0]
+                    vertex_color = color_layer.data[loop_index].color
 
                 # Add uvs
                 uvs = []

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -206,11 +206,12 @@ class IndexedTriangleSet(Node):
             for loop_index in triangle.loops:
                 blender_vertex = mesh.vertices[mesh.loops[loop_index].vertex_index]
 
+
                 # Add vertex color
                 vertex_color = None
                 if len(mesh.vertex_colors):
-                    # Get the color from the active layer, since only one vertex color layer is supported in GE
-                    vertex_color = mesh.vertex_colors.active.data[loop_index].color
+                    # Get the color from the first layer, since only one vertex color layer is supported in GE
+                    vertex_color = mesh.vertex_colors[0].data[loop_index].color
 
                 # Add uvs
                 uvs = []

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -92,7 +92,3 @@ with the use of a regex as detailed in this answer on stackoverflow https://stac
 
 def sort_blender_objects_by_outliner_ordering(objects: List[BlenderObject]) -> List[BlenderObject]:
     return sorted(objects, key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s.name)])
-
-
-def blender_version() -> int:
-    return int(bpy.app.version[0])

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -65,8 +65,8 @@ def as_fs_relative_path(filepath: str):
     filepath_clean = os.path.normpath(bpy.path.abspath(filepath))  # normpath cleans up stuff such as '../'
     logger.debug(f"Cleaned filepath: {filepath_clean}")
     fs_data_path = os.path.normpath(
-                        bpy.path.abspath(
-                            bpy.context.preferences.addons[__package__].preferences.fs_data_path))
+        bpy.path.abspath(
+            bpy.context.preferences.addons[__package__].preferences.fs_data_path))
     logger.debug(f"FS data path: {fs_data_path}")
     try:
         if fs_data_path != '':
@@ -82,10 +82,17 @@ def as_fs_relative_path(filepath: str):
 def sort_blender_objects_by_name(objects: List[BlenderObject]) -> List[BlenderObject]:
     return sorted(objects, key=lambda x: x.name)
 
+
 """
 Blenders outliner does not follow a stricly lexographical ordering, but rather what is called a "natural" ordering.
 This function implements the same ordering as per https://github.com/blender/blender/blob/b0e7a6db56caf6669b6fade1622710d70b96483e/source/blender/blenlib/intern/string.c#L727,
 with the use of a regex as detailed in this answer on stackoverflow https://stackoverflow.com/a/16090640
 """
+
+
 def sort_blender_objects_by_outliner_ordering(objects: List[BlenderObject]) -> List[BlenderObject]:
     return sorted(objects, key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s.name)])
+
+
+def blender_version() -> int:
+    return int(bpy.app.version[0])

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -65,8 +65,8 @@ def as_fs_relative_path(filepath: str):
     filepath_clean = os.path.normpath(bpy.path.abspath(filepath))  # normpath cleans up stuff such as '../'
     logger.debug(f"Cleaned filepath: {filepath_clean}")
     fs_data_path = os.path.normpath(
-        bpy.path.abspath(
-            bpy.context.preferences.addons[__package__].preferences.fs_data_path))
+                        bpy.path.abspath(
+                            bpy.context.preferences.addons[__package__].preferences.fs_data_path))
     logger.debug(f"FS data path: {fs_data_path}")
     try:
         if fs_data_path != '':
@@ -82,13 +82,10 @@ def as_fs_relative_path(filepath: str):
 def sort_blender_objects_by_name(objects: List[BlenderObject]) -> List[BlenderObject]:
     return sorted(objects, key=lambda x: x.name)
 
-
 """
 Blenders outliner does not follow a stricly lexographical ordering, but rather what is called a "natural" ordering.
 This function implements the same ordering as per https://github.com/blender/blender/blob/b0e7a6db56caf6669b6fade1622710d70b96483e/source/blender/blenlib/intern/string.c#L727,
 with the use of a regex as detailed in this answer on stackoverflow https://stackoverflow.com/a/16090640
 """
-
-
 def sort_blender_objects_by_outliner_ordering(objects: List[BlenderObject]) -> List[BlenderObject]:
     return sorted(objects, key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split('(\d+)', s.name)])


### PR DESCRIPTION
Fix to support materials export for Blender 4.0 with support for older versions.

Blender 4.0 change in Shader input naming:
Specular -> Specular IOR Level
Emission -> Emission Color

Fix Emissive color export since new blender has by default Emissive color 1 1 1 1. Now is emissive color exported when strength has non zero value