### PR TITLE
Add referenceId export

### DIFF
--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -234,6 +234,9 @@ class I3D:
     def add_file_shader(self, path_to_file: str) -> int:
         return self.add_file(Shader, path_to_file)
 
+    def add_file_reference(self, path_to_file: str) -> int:
+        return self.add_file(Reference, path_to_file)
+
     def get_setting(self, setting: str):
         return self.settings[setting]
 

--- a/addon/i3dio/node_classes/file.py
+++ b/addon/i3dio/node_classes/file.py
@@ -118,3 +118,7 @@ class Image(File):
 
 class Shader(File):
     MODHUB_FOLDER = 'shaders'
+
+
+class Reference(File):
+    MODHUB_FOLDER = 'assets'

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -153,6 +153,13 @@ class SceneGraphNode(Node):
         except AttributeError:
             pass
 
+    def _add_reference_file(self):
+        if self.blender_object.i3d_reference_path.reference_path == "":
+            return
+        self.logger.debug(f"Adding reference file")
+        file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path.reference_path)
+        self._write_attribute('referenceId', file_id)
+
     @property
     @abstractmethod
     def _transform_for_conversion(self) -> Union[mathutils.Matrix, None]:
@@ -206,6 +213,7 @@ class SceneGraphNode(Node):
         self._write_properties()
         self._write_user_attributes()
         self._add_transform_to_xml_element(self._transform_for_conversion)
+        self._add_reference_file()
 
     def add_child(self, node: SceneGraphNode):
         self.children.append(node)

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -154,10 +154,10 @@ class SceneGraphNode(Node):
             pass
 
     def _add_reference_file(self):
-        if self.blender_object.i3d_reference_path.reference_path == "":
+        if self.blender_object.i3d_reference_path == "" or not self.blender_object.i3d_reference_path.endswith('.i3d'):
             return
         self.logger.debug(f"Adding reference file")
-        file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path.reference_path)
+        file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path)
         self._write_attribute('referenceId', file_id)
 
     @property

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -816,16 +816,6 @@ class I3D_IO_PT_joint_attributes(Panel):
 
 
 @register
-class I3DReferencePath(bpy.types.PropertyGroup):
-    reference_path: StringProperty(
-        name="Reference Path",
-        description="Put the path to the .i3d file you want to reference here",
-        default='',
-        subtype='FILE_PATH'
-    )
-
-
-@register
 class I3D_IO_PT_reference_file(Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -841,7 +831,7 @@ class I3D_IO_PT_reference_file(Panel):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        layout.prop(context.object.i3d_reference_path, 'reference_path')
+        layout.prop(context.object, 'i3d_reference_path')
 
 
 @register
@@ -881,13 +871,18 @@ class I3D_IO_PT_mapping_attributes(Panel):
         row = layout.row()
         row.prop(obj.i3d_mapping, 'mapping_name')
 
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
     bpy.types.Object.i3d_attributes = PointerProperty(type=I3DNodeObjectAttributes)
     bpy.types.Object.i3d_merge_group_index = IntProperty(default = -1)
     bpy.types.Object.i3d_mapping = PointerProperty(type=I3DMappingData)
-    bpy.types.Object.i3d_reference_path = PointerProperty(type=I3DReferencePath)
+    bpy.types.Object.i3d_reference_path = StringProperty(
+        name="Reference Path",
+        description="Put the path to the .i3d file you want to reference here",
+        default='',
+        subtype='FILE_PATH')
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
 

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -816,6 +816,35 @@ class I3D_IO_PT_joint_attributes(Panel):
 
 
 @register
+class I3DReferencePath(bpy.types.PropertyGroup):
+    reference_path: StringProperty(
+        name="Reference Path",
+        description="Put the path to the .i3d file you want to reference here",
+        default='',
+        subtype='FILE_PATH'
+    )
+
+
+@register
+class I3D_IO_PT_reference_file(Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_label = 'Reference File'
+    bl_context = 'object'
+    bl_parent_id = 'I3D_IO_PT_object_attributes'
+
+    @classmethod
+    def poll(cls, context):
+        return context.object is not None and context.object.type == 'EMPTY'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        layout.prop(context.object.i3d_reference_path, 'reference_path')
+
+
+@register
 class I3DMappingData(bpy.types.PropertyGroup):
     is_mapped: BoolProperty(
         name="Add to mapping",
@@ -858,12 +887,14 @@ def register():
     bpy.types.Object.i3d_attributes = PointerProperty(type=I3DNodeObjectAttributes)
     bpy.types.Object.i3d_merge_group_index = IntProperty(default = -1)
     bpy.types.Object.i3d_mapping = PointerProperty(type=I3DMappingData)
+    bpy.types.Object.i3d_reference_path = PointerProperty(type=I3DReferencePath)
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
 
 def unregister():
     load_post.remove(handle_old_merge_groups)
     del bpy.types.Scene.i3dio_merge_groups
+    del bpy.types.Object.i3d_reference_path
     del bpy.types.Object.i3d_mapping
     del bpy.types.Object.i3d_merge_group_index
     del bpy.types.Object.i3d_attributes


### PR DESCRIPTION
Makes it possible to export referenced i3d files directly from blender.

Just add path to a .i3d asset
![image](https://github.com/StjerneIdioten/I3D-Blender-Addon/assets/57712777/73c9045e-e06e-4981-b393-c35e30545f65)

it will then be visible in the exported .i3d file.

(Only works on Empties)

