### PR TITLE
Fix export error when exporting "Everything"

### DIFF
--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -213,7 +213,8 @@ class SceneGraphNode(Node):
         self._write_properties()
         self._write_user_attributes()
         self._add_transform_to_xml_element(self._transform_for_conversion)
-        self._add_reference_file()
+        if not isinstance(self.blender_object, bpy.types.Collection):
+            self._add_reference_file()
 
     def add_child(self, node: SceneGraphNode):
         self.children.append(node)


### PR DESCRIPTION
When exporting "Everything", the collections will be added as transform groups in the final .i3d file, referenceId property is not assigned for collections obviously so that caused a export fail.

Fixed by simple checking if the blender_object is not a collection before calling _add_reference_file.