### PR TITLE
Fix parameter name and check for reference file on bones

### DIFF
--- a/addon/i3dio/node_classes/merge_group.py
+++ b/addon/i3dio/node_classes/merge_group.py
@@ -23,7 +23,7 @@ class MergeGroupRoot(ShapeNode):
                  parent: [SceneGraphNode or None] = None):
         self.merge_group_name = i3d.merge_groups[merge_group_object.i3d_merge_group_index].name
         self.skin_bind_ids = f"{id_:d} "
-        super().__init__(id_=id_, mesh_object=merge_group_object, i3d=i3d, parent=parent)
+        super().__init__(id_=id_, shape_object=merge_group_object, i3d=i3d, parent=parent)
 
     # Override default shape behaviour to use the merge group mesh name instead of the blender objects name
     def add_shape(self):

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -154,7 +154,9 @@ class SceneGraphNode(Node):
             pass
 
     def _add_reference_file(self):
-        if self.blender_object.i3d_reference_path == "" or not self.blender_object.i3d_reference_path.endswith('.i3d'):
+        if 'i3d_reference_path' not in self.blender_object.keys():
+            return
+        elif self.blender_object.i3d_reference_path == "" or not self.blender_object.i3d_reference_path.endswith('.i3d'):
             return
         self.logger.debug(f"Adding reference file")
         file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path)

--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -99,7 +99,7 @@ class SkinnedMeshShapeNode(ShapeNode):
             if modifier.type == 'ARMATURE':
                 self.armature_nodes.append(i3d.add_armature(modifier.object))
         self.bone_mapping = ChainMap(*[armature.bone_mapping for armature in self.armature_nodes])
-        super().__init__(id_=id_, mesh_object=skinned_mesh_object, i3d=i3d, parent=parent)
+        super().__init__(id_=id_, shape_object=skinned_mesh_object, i3d=i3d, parent=parent)
 
     def add_shape(self):
         # Use a ChainMap to easily combine multiple bone mappings and get around any problems with multiple bones


### PR DESCRIPTION
merge_group.py and skinned_mesh.py fix using wrong parameter on inherited class init.

export reference file fix, when function has been executed on bones