### PR TITLE
feat: changed setting to boolean for vertex colors and alpha blending…

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -183,7 +183,7 @@ class Material(Node):
 
     def _write_properties(self):
         # Alpha blending
-        if self.blender_material.blend_method in ['CLIP', 'HASHED', 'BLEND']:
+        if self.blender_material.i3d_attributes.alpha_blending:
             self._write_attribute('alphaBlending', True)
 
     def _export_shader_settings(self):

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -205,10 +205,11 @@ class IndexedTriangleSet(Node):
 
                 # Add vertex color
                 vertex_color = None
-                if len(mesh.vertex_colors):
-                    # Get the color from the active layer or first layer, since only one vertex color layer is supported in GE
-                    color_layer = mesh.vertex_colors.active if mesh.vertex_colors.active is not None else mesh.vertex_colors[0]
-                    vertex_color = color_layer.data[loop_index].color
+                if mesh.i3d_attributes.use_vertex_color:
+                    if len(mesh.vertex_colors):
+                        # Get the color from the active layer or first layer, since only one vertex color layer is supported in GE
+                        color_layer = mesh.vertex_colors.active if mesh.vertex_colors.active is not None else mesh.vertex_colors[0]
+                        vertex_color = color_layer.data[loop_index].color
 
                 # Add uvs
                 uvs = []

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -105,6 +105,12 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         type=bpy.types.Object,
 		)
 
+    use_vertex_color: BoolProperty(
+        name="Use Vertex Color",
+        default=False,
+        description="If enabled, vertex color will be exported"
+    )
+
 
 @register
 class I3D_IO_PT_shape_attributes(Panel):
@@ -133,6 +139,7 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "nav_mesh_mask")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')
+        layout.prop(obj.i3d_attributes, "use_vertex_color")
 
 
 @register

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.types import (Panel)
 from bpy.props import (
+    BoolProperty,
     StringProperty,
     PointerProperty,
     EnumProperty,
@@ -269,6 +270,7 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
                             set=variation_setter
                             )
 
+    alpha_blending: BoolProperty(name='Alpha Blending', default=False, description='Enable alpha blending for this material')
     variations: CollectionProperty(type=I3DShaderVariation)
     shader_parameters: CollectionProperty(type=I3DShaderParameter)
     shader_textures: CollectionProperty(type=I3DShaderTexture)
@@ -290,6 +292,8 @@ class I3D_IO_PT_shader(Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
         material = bpy.context.active_object.active_material
+
+        layout.prop(material.i3d_attributes, 'alpha_blending')
 
         layout.prop(material.i3d_attributes, 'source')
         if material.i3d_attributes.variations:


### PR DESCRIPTION
Changed Alpha Blending settings from Blender material option to user options. For now it is under shader, because there is no better place.

Changed exporting setting for vertex colors instead of default always export v.colors, now user have check box. -> Main reason is that some of the addons are using v.colors for operations, so model can have v.colors and will be exported even when it is not necessary.