### PR TITLE
fix(material): update alpha blending to use surface_render_method

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -183,7 +183,7 @@ class Material(Node):
 
     def _write_properties(self):
         # Alpha blending
-        if self.blender_material.blend_method in ['CLIP', 'HASHED', 'BLEND']:
+        if self.blender_material.surface_render_method == 'BLENDED':
             self._write_attribute('alphaBlending', True)
 
     def _export_shader_settings(self):


### PR DESCRIPTION
The Material.blend_method API is deprecated as of Blender 4.2. Updated the exporter to use the new Material.surface_render_method instead.