### PR TITLE
fix(light): update light type mapping for SUN to directional

### DIFF
--- a/addon/i3dio/ui/light.py
+++ b/addon/i3dio/ui/light.py
@@ -30,7 +30,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
                           'default': 'point',
                           'tracking': {'member_path': 'type',
                                        'mapping': {'POINT': 'point',
-                                                   'SUN': 'point',
+                                                   'SUN': 'directional',
                                                    'SPOT': 'spot',
                                                    'AREA': 'directional'}
                                        }


### PR DESCRIPTION
In a map a light called "sun" use type "directional" so I think this change make sense.