### PR TITLE
feat(skinned-mesh): add support for 'Child Of' constraint on bones

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -186,22 +186,31 @@ def _export(i3d: I3D, objects: List[BlenderObject], sort_alphabetical: bool = Tr
     objects_to_export = objects
     if sort_alphabetical:
         objects_to_export = sort_blender_objects_by_outliner_ordering(objects)
-    all_objects_to_export = [obj for root_obj in objects for obj in traverse_hierarchy(root_obj)]
+
+    new_objects_to_export = [obj for root_obj in objects for obj in traverse_hierarchy(root_obj)]
+    for obj in new_objects_to_export:
+        if obj not in i3d.all_objects_to_export:
+            i3d.all_objects_to_export.append(obj)
+
     for blender_object in objects_to_export:
-        _add_object_to_i3d(i3d, blender_object, export_candidates=all_objects_to_export)
+        _add_object_to_i3d(i3d, blender_object)
 
-    for bone_object, target in i3d.deferred_constraints:
-        i3d.logger.debug(f"Deferred constraint: {bone_object} -> {target}")
+    for armature, bone_object, target in i3d.deferred_constraints:
+        i3d.logger.debug(f"Processing deferred constraint for: {bone_object}, Target: {target}")
+
         if target in i3d.processed_objects:
-            parent = i3d.processed_objects[target]
-            i3d.logger.debug(f"Processing deferred CHILD_OF constraint for {bone_object.name} -> {target}")
-            i3d.add_bone(bone_object, parent, is_child_of=True)
-        else:
-            i3d.logger.warning(f"Unresolved CHILD_OF constraint for {bone_object.name}: {target}")
+            i3d.logger.debug(f"Target object '{target}' is included in the export hierarchy. Setting bone parent.")
+            bone_name = bone_object.name
+            bone = next((b for b in i3d.skinned_meshes[armature.name].bones if b.name == bone_name), None)
+
+            if bone is not None:
+                i3d.skinned_meshes[armature.name].update_bone_parent(None, custom_target=i3d.processed_objects[target],
+                                                                     bone=bone)
+            else:
+                i3d.logger.warning(f"Could not find bone {bone_name} in the armature's bone list!")
 
 
-def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None,
-                       export_candidates: list = None) -> None:
+def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None) -> None:
     # Check if object should be excluded from export (including its children)
     if obj.i3d_attributes.exclude_from_export:
         logger.info(f"Skipping [{obj.name}] and its children. Excluded from export.")
@@ -240,7 +249,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                             logger.warning(f"Armature modifier '{modifier.name}' on skinned mesh '{obj.name}' "
                                            "has no armature object assigned. Exporting as a regular shape instead.")
                             break
-                        elif modifier.object not in export_candidates:
+                        elif modifier.object not in i3d.all_objects_to_export:
                             logger.warning(
                                 f"Skinned mesh '{obj.name}' references armature '{modifier.object.name}', "
                                 "but the armature is not included in the export hierarchy. "
@@ -285,7 +294,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
         # https://docs.blender.org/api/current/bpy.types.Object.html#bpy.types.Object.children
         logger.debug(f"[{obj.name}] processing objects children")
         for child in sort_blender_objects_by_outliner_ordering(obj.children):
-            _add_object_to_i3d(i3d, child, node, export_candidates)
+            _add_object_to_i3d(i3d, child, node)
         logger.debug(f"[{obj.name}] no more children to process in object")
 
 
@@ -307,7 +316,8 @@ def _process_collection_objects(i3d: I3D, collection: bpy.types.Collection, pare
         # a part of the collections objects. Which means that they would be added twice without this check. One for the
         # object itself and one for the collection.
         if child.parent is None:
-            _add_object_to_i3d(i3d, child, parent, export_candidates=collection.objects)
+            i3d.all_objects_to_export.append(child)
+            _add_object_to_i3d(i3d, child, parent)
     logger.debug(f"[{collection.name}] no more objects to process in collection")
 
 

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -176,6 +176,15 @@ def _export(i3d: I3D, objects: List[BlenderObject], sort_alphabetical: bool = Tr
     for blender_object in objects_to_export:
         _add_object_to_i3d(i3d, blender_object, export_candidates=all_objects_to_export)
 
+    for bone_object, target in i3d.deferred_constraints:
+        i3d.logger.debug(f"Deferred constraint: {bone_object} -> {target}")
+        if target in i3d.processed_objects:
+            parent = i3d.processed_objects[target]
+            i3d.logger.debug(f"Processing deferred CHILD_OF constraint for {bone_object.name} -> {target}")
+            i3d.add_bone(bone_object, parent, is_child_of=True)
+        else:
+            i3d.logger.warning(f"Unresolved CHILD_OF constraint for {bone_object.name}: {target}")
+
 
 def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None,
                        export_candidates: list = None) -> None:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -183,7 +183,7 @@ class Material(Node):
 
     def _write_properties(self):
         # Alpha blending
-        if self.blender_material.blend_method in ['CLIP', 'HASHED', 'BLEND']:
+        if self.blender_material.surface_render_method == 'BLENDED':
             self._write_attribute('alphaBlending', True)
 
     def _export_shader_settings(self):

--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -4,22 +4,26 @@ but it helps with debugging big trees and seeing the structure.
 """
 from __future__ import annotations
 from typing import (Union, Dict, List)
-from collections import ChainMap
+from collections import (ChainMap, namedtuple)
 import mathutils
 import bpy
+import math
 
 from .node import (TransformGroupNode, SceneGraphNode)
 from .shape import (ShapeNode, EvaluatedMesh)
 from ..i3d import I3D
 from .. import xml_i3d
 
-import math
+
+AssignParentResult = namedtuple('AssignParentResult', ['parent', 'is_child_of', 'deferred'])
 
 
 class SkinnedMeshBoneNode(TransformGroupNode):
-    def __init__(self, id_: int, bone_object: bpy.types.Bone,
-                 i3d: I3D, parent: SceneGraphNode, is_child_of: bool = False):
+    def __init__(self, id_: int, bone_object: bpy.types.Bone, i3d: I3D, parent: SceneGraphNode,
+                 is_child_of: bool = False, armature_object: bpy.types.Object = None, target: bpy.types.Object = None):
         self.is_child_of = is_child_of
+        self.armature_object = armature_object
+        self.target = target  # Used for deferred constraints
         super().__init__(id_=id_, empty_object=bone_object, i3d=i3d, parent=parent)
 
     def _matrix_to_i3d_space(self, matrix: mathutils.Matrix) -> mathutils.Matrix:
@@ -27,6 +31,10 @@ class SkinnedMeshBoneNode(TransformGroupNode):
 
     @property
     def _transform_for_conversion(self) -> mathutils.Matrix:
+        """
+        Calculate the bone's transformation matrix in I3D space, considering parenting and deferred constraints.
+        Handles scenarios like direct parenting, deferred CHILD_OF constraints, and collapsed armatures.
+        """
         if self.blender_object.parent and isinstance(self.blender_object.parent, bpy.types.Bone):
             # For bones parented to other bones, matrix_local is relative to the parent.
             # No transformation to I3D space is needed because the orientation is already relative to the parent bone.
@@ -42,21 +50,40 @@ class SkinnedMeshBoneNode(TransformGroupNode):
         bone_matrix = rot_fix @ bone_matrix.to_3x3().to_4x4()
         bone_matrix.translation = translation
 
-        if self.is_child_of:
+        self.logger.debug(f"bone settings: {self.is_child_of} {self.target}")
+
+        if self.is_child_of and self.parent.blender_object is not None:
             # Bone is parented to a CHILD_OF constraint target, collapse_armature doesn't matter here
             # Multiply the bone's local transform with the inverse of the parent object's world matrix
             # to correctly position it relative to its new parent
             parent_matrix = self._matrix_to_i3d_space(self.parent.blender_object.matrix_world)
+            if self.armature_object is not None:
+                # If the armature object is also present, include its local matrix in the calculation
+                armature_matrix = self._matrix_to_i3d_space(self.armature_object.matrix_local)
+                return parent_matrix.inverted() @ armature_matrix @ bone_matrix
             return parent_matrix.inverted() @ bone_matrix
+        elif self.target is not None:
+            # Bone is parented to a deferred CHILD_OF constraint target
+            # Multiply the bone's local transform with the inverse of the target's world matrix
+            # to correctly position it relative to its new parent
+            target_matrix = self._matrix_to_i3d_space(self.target.matrix_world)
+            return target_matrix.inverted() @ bone_matrix
 
         # For bones parented directly to the armature, matrix_local already represents their transform
         # relative to the armature, so no additional adjustments are needed.
-        if self.i3d.settings['collapse_armatures'] and self.parent.blender_object:
+        if self.i3d.settings['collapse_armatures'] and self.parent.blender_object is not None:
             # If collapse_armatures is enabled, the armature is removed in the I3D.
             # The root bone replaces the armature in the hierarchy,
             # so multiply its matrix with the armature matrix to preserve the correct transformation.
             armature_matrix = self._matrix_to_i3d_space(self.parent.blender_object.matrix_local)
             return armature_matrix @ bone_matrix
+
+        if self.armature_object is not None:
+            # In some rare cases when armature is collapsed and bone ends up being parented to scene root,
+            # we have to multiply the bone's matrix with its armature's world matrix to ensure correct positioning.
+            armature_matrix = self._matrix_to_i3d_space(self.armature_object.matrix_world)
+            return armature_matrix @ bone_matrix
+
         # Return the bone's local transform unchanged, as it is already correct relative to the armature.
         return bone_matrix
 
@@ -68,6 +95,7 @@ class SkinnedMeshRootNode(TransformGroupNode):
         # but dicts should be ordered going forwards in python
         self.bones: List[SkinnedMeshBoneNode] = list()
         self.bone_mapping: Dict[str, int] = {}
+        self.armature_object = armature_object
         # To determine if we just added the armature through a modifier lookup or knows its position in the scenegraph
         self.is_located = False
 
@@ -78,54 +106,97 @@ class SkinnedMeshRootNode(TransformGroupNode):
                 self._add_bone(bone, self)
 
     def add_i3d_mapping_to_xml(self):
-        """Wont export armature mapping, if 'collapsing armatures' is enabled
-        """
+        """Wont export armature mapping, if 'collapsing armatures' is enabled"""
         if not self.i3d.settings['collapse_armatures']:
             super().add_i3d_mapping_to_xml()
 
-    def _add_bone(self, bone_object: bpy.types.Bone, parent: Union[SkinnedMeshBoneNode, SkinnedMeshRootNode]):
+    def _add_bone(self, bone_object: bpy.types.Bone, parent: SceneGraphNode):
         """Recursive function for adding a bone along with all of its children"""
+        target = None
         is_child_of = False
 
-        # Try to find pose bone for the bone object
-        if pose_bone := self.blender_object.pose.bones.get(bone_object.name):
-            processed_objects = self.i3d.processed_objects
-
-            # Check if pose pose bone has a CHILD_OF constraint
+        # Check for CHILD_OF constraint
+        if (pose_bone := self.blender_object.pose.bones.get(bone_object.name)) is not None:
             child_of = next((c for c in pose_bone.constraints if c.type == 'CHILD_OF'), None)
-            if child_of and child_of.target:
-                target = child_of.target
-                if target not in processed_objects:
-                    # Target object has not been processed yet, defer the constraint
-                    self.logger.debug(f"Deferring CHILD_OF constraint for {bone_object.name} -> {target}")
-                    self.i3d.deferred_constraints.append((bone_object, target, None))
-                    return
+            if child_of:
+                if not child_of.target:
+                    self.logger.warning(f"CHILD_OF constraint on {bone_object.name} has no target. Ignoring.")
                 else:
-                    # Use the target object if no subtarget is specified
-                    self.logger.debug(f"Bone {bone_object} is child of {target}")
-                    parent = processed_objects[target]
-                    is_child_of = True
+                    target = child_of.target
+                    result = self.assign_parent(bone_object, parent, target)
+                    parent = result.parent
+                    is_child_of = result.is_child_of
 
-        self.bones.append(self.i3d.add_bone(bone_object, parent, is_child_of=is_child_of))
+                    if result.deferred:
+                        self.i3d.deferred_constraints.append((self.armature_object, bone_object, target))
+                        self.logger.debug(f"Deferred constraint added for: {bone_object}, target: {target}")
+
+        self.bones.append(self.i3d.add_bone(bone_object, parent, is_child_of=is_child_of,
+                                            armature_object=self.armature_object, target=target))
         current_bone = self.bones[-1]
         self.bone_mapping[bone_object.name] = current_bone.id
 
         for child_bone in bone_object.children:
             self._add_bone(child_bone, current_bone)
 
-    def update_bone_parent(self, parent):
-        for bone in self.bones:
-            if bone.parent == self:
-                self.element.remove(bone.element)
-                self.children.remove(bone)
-                if parent is not None:
-                    bone.parent = parent
-                    parent.add_child(bone)
-                    parent.element.append(bone.element)
-                else:
-                    bone.parent = None
-                    self.i3d.scene_root_nodes.append(bone)
-                    self.i3d.xml_elements['Scene'].append(bone.element)
+    def update_bone_parent(self, parent: SceneGraphNode = None,
+                           custom_target: SceneGraphNode = None, bone: SkinnedMeshBoneNode = None):
+        """Updates the parent of bones"""
+        if custom_target is not None and bone is not None:
+            self._assign_bone_parent(bone, custom_target)
+        else:
+            for bone in self.bones:
+                if bone.parent == self:
+                    new_parent = parent or None
+                    self._assign_bone_parent(bone, new_parent)
+
+    def _assign_bone_parent(self, bone: SkinnedMeshBoneNode, new_parent: SceneGraphNode):
+        """Assigns a new parent to a bone and updates the scene graph"""
+        self.logger.debug(f"Updating parent for {bone} to {new_parent}")
+        # Remove bone from its current parent
+        if bone.parent == self:
+            self.logger.debug(f"Removing {bone} from current parent")
+            self.element.remove(bone.element)
+            self.children.remove(bone)
+
+        # Add to the new parent or scene root
+        if new_parent:
+            if bone in self.i3d.scene_root_nodes:
+                # If collapse armature is enabled the bone would have moved to the scene root,
+                # but since we are now moving it to a new parent we have to remove it from the scene root
+                # Or else we can get problems with i3dmappings
+                self.logger.debug(f"Removing {bone} from scene root")
+                self.i3d.scene_root_nodes.remove(bone)
+                self.i3d.xml_elements['Scene'].remove(bone.element)
+            self.logger.debug(f"Adding {bone} to {new_parent}")
+            bone.parent = new_parent
+            new_parent.add_child(bone)
+            new_parent.element.append(bone.element)
+        else:
+            self.logger.debug(f"Adding {bone} to scene root")
+            bone.parent = None
+            self.i3d.scene_root_nodes.append(bone)
+            self.i3d.xml_elements['Scene'].append(bone.element)
+
+    def assign_parent(self, bone_object: bpy.types.Bone, parent: SceneGraphNode,
+                      target: bpy.types.Object) -> AssignParentResult:
+        """
+        Assign the parent for a bone. Returns the assigned parent, whether the bone is a child of a target,
+        and whether the assignment is deferred.
+        """
+        if target in self.i3d.processed_objects:
+            # Target is processed, use it as the parent
+            self.logger.debug(f"Target {target} is processed. Assigning as parent for {bone_object}.")
+            return AssignParentResult(parent=self.i3d.processed_objects[target], is_child_of=True, deferred=False)
+
+        if target not in self.i3d.all_objects_to_export:
+            # Target is not in the export list, fallback to the original parent
+            self.logger.debug(f"Target {target} is not in the export list. Using original parent for {bone_object}.")
+            return AssignParentResult(parent=parent, is_child_of=False, deferred=False)
+
+        # Defer the constraint and temporarily keep the original parent
+        self.logger.debug(f"Deferring CHILD_OF constraint for {bone_object}, target: {target}")
+        return AssignParentResult(parent=parent, is_child_of=False, deferred=True)
 
 
 class SkinnedMeshShapeNode(ShapeNode):

--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -16,6 +16,7 @@ from .. import xml_i3d
 
 import math
 
+
 class SkinnedMeshBoneNode(TransformGroupNode):
     def __init__(self, id_: int, bone_object: bpy.types.Bone,
                  i3d: I3D, parent: SceneGraphNode):


### PR DESCRIPTION
Make it possible for bones in armatures to set a custom parent
based on the 'Child Of' constraint target (PoseBone). Simplifies
the workflow by allowing a single armature to manage
all bones, instead of requiring one armature per bone.
[childOfConstraint.zip](https://github.com/user-attachments/files/18413527/childOfConstraint.zip)
