### PR TITLE
feat(attributes): add new FS25 attributes & reorganized a little

### DIFF
--- a/addon/i3dio/__init__.py
+++ b/addon/i3dio/__init__.py
@@ -72,21 +72,23 @@ def register():
     ui.udim_picker.register()
     ui.shader_picker.register()
     ui.exporter.register()
+    ui.collision_data.register()
     ui.object.register()
     ui.user_attributes.register()
     ui.mesh.register()
     ui.light.register()
     bpy.types.TOPBAR_MT_file_export.append(ui.exporter.menu_func_export)
 
+
 def unregister():
     bpy.types.TOPBAR_MT_file_export.remove(ui.exporter.menu_func_export)
     ui.exporter.unregister()
     ui.user_attributes.unregister()
     ui.object.unregister()
+    ui.collision_data.unregister()
     ui.mesh.unregister()
     ui.light.unregister()
     ui.shader_picker.unregister()
     ui.udim_picker.unregister()
     ui.addon_preferences.unregister()
     ui.helper_functions.unregister()
-

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -154,13 +154,14 @@ class SceneGraphNode(Node):
             pass
 
     def _add_reference_file(self):
-        if 'i3d_reference_path' not in self.blender_object.keys():
+        reference = self.blender_object.i3d_reference
+        if reference.path == "" or not reference.path.endswith('.i3d'):
             return
-        elif self.blender_object.i3d_reference_path == "" or not self.blender_object.i3d_reference_path.endswith('.i3d'):
-            return
-        self.logger.debug(f"Adding reference file")
-        file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path)
+
+        self.logger.debug("Adding reference file")
+        file_id = self.i3d.add_file_reference(reference.path)
         self._write_attribute('referenceId', file_id)
+        self._write_attribute('referenceRuntimeLoaded', reference.runtime_loaded)
 
     @property
     @abstractmethod

--- a/addon/i3dio/ui/__init__.py
+++ b/addon/i3dio/ui/__init__.py
@@ -4,6 +4,7 @@ if "bpy" in locals():
         'helper_functions',
         'addon_preferences',
         'exporter',
+        'collision_data',
         'object',
         'mesh',
         'light',
@@ -16,5 +17,5 @@ if "bpy" in locals():
         if module_name in locals():
             importlib.reload(locals()[module_name])
 
-from . import (helper_functions, addon_preferences, exporter, object, user_attributes, mesh, light, shader_picker,
-               udim_picker)
+from . import (helper_functions, addon_preferences, exporter, collision_data, object, user_attributes, mesh, light,
+               shader_picker, udim_picker)

--- a/addon/i3dio/ui/collision_data.py
+++ b/addon/i3dio/ui/collision_data.py
@@ -3,6 +3,7 @@ from .. import xml_i3d
 from pathlib import Path
 from bpy.app.handlers import (persistent, load_post)
 from collections import namedtuple
+from .. import __package__ as base_package
 
 
 COLLISIONS = {
@@ -123,7 +124,7 @@ def populate_collision_enum_list() -> None:
 
 def populate_collision_cache() -> None:
     """Populate the COLLISIONS cache from XML files."""
-    data_path = Path(bpy.context.preferences.addons['i3dio'].preferences.fs_data_path)
+    data_path = Path(bpy.context.preferences.addons[base_package].preferences.fs_data_path)
     shared_dir = data_path.parent / 'shared'
     flags_path = shared_dir / 'collisionMaskFlags.xml'
     rules_path = shared_dir / 'collisionMaskConversionRules.xml'

--- a/addon/i3dio/ui/collision_data.py
+++ b/addon/i3dio/ui/collision_data.py
@@ -1,0 +1,236 @@
+import bpy
+from .. import xml_i3d
+from pathlib import Path
+from bpy.app.handlers import (persistent, load_post)
+from collections import namedtuple
+
+
+COLLISIONS = {
+    'flags': {},  # {name: bit}
+    'presets': {},  # {name: CollisionPreset}
+    'rules': []  # List[CollisionRule]
+}
+
+COLLISIONS_ENUM_LIST_DEFAULT = ('NONE', 'No Preset', 'No Collision preset set')
+COLLISIONS_ENUM_LIST = [COLLISIONS_ENUM_LIST_DEFAULT]
+
+CollisionPreset = namedtuple('CollisionPreset', ['name', 'group', 'group_hex', 'mask', 'mask_hex', 'desc'])
+CollisionOutput = namedtuple('CollisionOutput', ['preset', 'group', 'mask', 'without_flags', 'is_trigger'])
+CollisionRule = namedtuple('CollisionRule', ['mask_old', 'outputs'])
+
+
+def compute_bitmask(flags, flag_dict):
+    return sum(1 << flag_dict[flag] for flag in flags if flag in flag_dict)
+
+
+def parse_collision_mask_flags(filepath) -> None:
+    """Parse collisionMaskFlags.xml to populate flags and presets."""
+    global COLLISIONS
+
+    tree = xml_i3d.parse(filepath)
+    if tree is None:
+        print(f"Failed to parse {filepath}")
+        return None
+
+    root = tree.getroot()
+
+    # Parse flags
+    COLLISIONS['flags'] = {flag.get('name'): int(flag.get('bit')) for flag in root.findall('./flag')}
+
+    # Parse presets
+    for preset in root.findall('./preset'):
+        name = preset.get('name')
+        group_flags = [flag.get('name') for flag in preset.findall('./group/flag')]
+        desc = preset.get('desc')
+
+        # Compute the group hex
+        group_hex = f"{compute_bitmask(group_flags, COLLISIONS['flags']):x}"
+
+        # Handle the <mask> element
+        mask_value = 0
+        mask_element = preset.find('./mask')
+        if mask_element is not None:
+            # Some mask elements have a direct value attribute
+            direct_value = mask_element.get('value')
+            if direct_value is not None:
+                try:
+                    mask_value = int(direct_value, 16)
+                except ValueError:
+                    print(f"Invalid mask value '{direct_value}' in preset '{name}'")
+                    continue
+            else:
+                # If no single value attribute, compute the bitmask from the flags
+                mask_value = compute_bitmask([flag.get('name') for flag in
+                                              mask_element.findall('./flag')], COLLISIONS['flags'])
+
+        mask_hex = f"{mask_value:x}"
+        COLLISIONS['presets'][name] = CollisionPreset(name, group_flags, group_hex, mask_value, mask_hex, desc)
+
+
+def parse_collision_mask_rules(filepath) -> None:
+    """Parse collisionMaskConversionRules.xml to populate conversion rules."""
+    global COLLISIONS
+
+    tree = xml_i3d.parse(filepath)
+    if tree is None:
+        print(f"Failed to parse {filepath}")
+        return None
+
+    root = tree.getroot()
+
+    for rule in root.findall('./conversionRules/rule'):
+        mask_old = int(rule.get('maskOld'))
+        outputs = []
+
+        for output in rule.findall('./output'):
+            preset = output.get('preset')
+            is_trigger = output.get('isTrigger', 'false').lower() == 'true'
+            group_flags = [flag.get('name') for flag in output.findall('./group/flag')]
+
+            # Check for a value in the mask element
+            mask_element = output.find('./mask')
+            mask_value = mask_element.get('value') if mask_element is not None else None
+            if mask_value is not None:
+                try:
+                    mask_flags = int(mask_value, 16)
+                except ValueError:
+                    print(f"Invalid mask value '{mask_value}' in rule for maskOld '{mask_old}'")
+                    mask_flags = 0
+            else:
+                # Parse individual flag names
+                mask_flags = [flag.get('name') for flag in output.findall('./mask/flag')]
+
+            without_flags = [flag.get('name') for flag in output.findall('./mask/withoutFlag')]
+
+            outputs.append(CollisionOutput(preset, group_flags, mask_flags, without_flags, is_trigger))
+
+        COLLISIONS['rules'].append(CollisionRule(mask_old, outputs))
+
+
+def populate_collision_enum_list() -> None:
+    """Populate COLLISIONS_ENUM_LIST with collision presets."""
+    global COLLISIONS, COLLISIONS_ENUM_LIST
+
+    if not COLLISIONS['presets']:
+        print("No collision presets available to populate the enum list.")
+        return
+
+    COLLISIONS_ENUM_LIST.extend([
+        (preset.name, preset.name, preset.desc or f"Collision preset: {preset.name}")
+        for preset in COLLISIONS['presets'].values()
+    ])
+
+
+def populate_collision_cache() -> None:
+    """Populate the COLLISIONS cache from XML files."""
+    data_path = Path(bpy.context.preferences.addons['i3dio'].preferences.fs_data_path)
+    shared_dir = data_path.parent / 'shared'
+    flags_path = shared_dir / 'collisionMaskFlags.xml'
+    rules_path = shared_dir / 'collisionMaskConversionRules.xml'
+
+    # Parse XML files
+    if flags_path.exists():
+        parse_collision_mask_flags(flags_path)
+    else:
+        print(f"Collision flags file not found: {flags_path}")
+
+    if rules_path.exists():
+        parse_collision_mask_rules(rules_path)
+    else:
+        print(f"Collision rules file not found: {rules_path}")
+
+    # Populate the enum list
+    populate_collision_enum_list()
+
+
+def apply_rule_to_mask(rule: CollisionRule, is_trigger: bool) -> dict[str, str]:
+    """Apply a collision rule based on the `isTrigger` condition."""
+    global COLLISIONS
+
+    def _get_bitmask(flags: list[str], flag_map: dict[str, int]) -> int:
+        """Compute the bitmask for a list of flags."""
+        bitmask = 0
+        for flag in flags:
+            if flag in flag_map:
+                bitmask |= (1 << flag_map[flag])
+            else:
+                print(f"Unknown flag '{flag}'.")
+        return bitmask
+
+    # Find mathcing output, in maskOld="1073741824" there is 2 outputs, one for trigger and one for non-trigger
+    output = next((o for o in rule.outputs if o.is_trigger == is_trigger), None)
+    if not output:
+        print(f"No matching output for trigger={is_trigger}")
+        return {'group_hex': '0', 'mask_hex': '0'}
+
+    group_value = 0
+    mask_value = 0
+
+    if output.preset:
+        preset = COLLISIONS['presets'][output.preset]
+        group_value = compute_bitmask(preset.group, COLLISIONS['flags'])
+        mask_value = preset.mask
+
+    # Add group & mask flags
+    group_value |= _get_bitmask(output.group, COLLISIONS['flags'])
+    if isinstance(output.mask, int):
+        mask_value = output.mask  # Directly set the mask value if it's an integer e.g.: <mask value="1"/>
+    else:
+        mask_value |= _get_bitmask(output.mask, COLLISIONS['flags'])
+
+    # Remove flags specified in `withoutFlag`: <withoutFlag name="TERRAIN_DELTA" />
+    for flag in output.without_flags:
+        if flag in COLLISIONS['flags']:
+            mask_value &= ~(1 << COLLISIONS['flags'][flag])
+        else:
+            print(f"Unknown withoutFlag '{flag}' in rule.")
+
+    return {'group_hex': f"{group_value:x}", 'mask_hex': f"{mask_value:x}"}
+
+
+@persistent
+def convert_old_collision_masks(dummy) -> None:
+    global COLLISIONS
+    rule_lookup = {rule.mask_old: rule for rule in COLLISIONS['rules']}
+
+    for obj in bpy.data.objects:
+        if obj.type != 'MESH':
+            print(f"Skipping non-mesh object: {obj.name}")
+            continue
+
+        if (old_mask_hex := obj.i3d_attributes.get('collision_mask')) is not None:
+            try:
+                old_mask_decimal = int(old_mask_hex, 16)  # Convert to decimal
+            except ValueError:
+                print(f"Invalid collision mask '{old_mask_hex}' for object '{obj.name}'")
+                continue
+
+            # Get all matching rules for this mask
+            rule = rule_lookup.get(old_mask_decimal)
+            if not rule:
+                print(f"No rule found for mask '{old_mask_hex}' for object '{obj.name}'")
+                continue
+
+            is_trigger = getattr(obj.i3d_attributes, 'trigger', False)
+            # Apply the rule to calculate the new values
+            result = apply_rule_to_mask(rule, is_trigger)
+
+            # If a preset is specified, set the collisions_preset
+            if (preset_name := next((output.preset for output in rule.outputs if output.preset), None)):
+                obj.i3d_attributes.collisions_preset = preset_name
+
+            # Assign the computed values
+            obj.i3d_attributes.collision_filter_group = result['group_hex']
+            obj.i3d_attributes.collision_filter_mask = result['mask_hex']
+
+            print(f"Converted collision mask for '{obj.name}': "
+                  f"group='{result['group_hex']}', mask='{result['mask_hex']}', trigger={is_trigger}")
+
+
+def register():
+    populate_collision_cache()
+    load_post.append(convert_old_collision_masks)
+
+
+def unregister():
+    load_post.remove(convert_old_collision_masks)

--- a/addon/i3dio/ui/collision_data.py
+++ b/addon/i3dio/ui/collision_data.py
@@ -195,20 +195,19 @@ def convert_old_collision_masks(dummy) -> None:
 
     for obj in bpy.data.objects:
         if obj.type != 'MESH':
-            print(f"Skipping non-mesh object: {obj.name}")
             continue
 
         if (old_mask_hex := obj.i3d_attributes.get('collision_mask')) is not None:
             try:
                 old_mask_decimal = int(old_mask_hex, 16)  # Convert to decimal
             except ValueError:
-                print(f"Invalid collision mask '{old_mask_hex}' for object '{obj.name}'")
+                print(f"Invalid collision mask '{old_mask_hex}' for object '{obj.name}', skipping.")
                 continue
 
             # Get all matching rules for this mask
             rule = rule_lookup.get(old_mask_decimal)
             if not rule:
-                print(f"No rule found for mask '{old_mask_hex}' for object '{obj.name}'")
+                print(f"No rule found for mask '{old_mask_hex}' for object '{obj.name}', skipping.")
                 continue
 
             is_trigger = getattr(obj.i3d_attributes, 'trigger', False)
@@ -222,6 +221,8 @@ def convert_old_collision_masks(dummy) -> None:
             # Assign the computed values
             obj.i3d_attributes.collision_filter_group = result['group_hex']
             obj.i3d_attributes.collision_filter_mask = result['mask_hex']
+
+            del obj.i3d_attributes['collision_mask']
 
             print(f"Converted collision mask for '{obj.name}': "
                   f"group='{result['group_hex']}', mask='{result['mask_hex']}', trigger={is_trigger}")

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -8,15 +8,11 @@ from bpy.props import (
     BoolProperty,
     EnumProperty,
     PointerProperty,
-    FloatProperty,
     IntProperty,
-    CollectionProperty,    
-    FloatVectorProperty,
 )
 
 classes = []
 
-from ..xml_i3d import i3d_max
 
 def register(cls):
     classes.append(cls)
@@ -28,14 +24,20 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
     i3d_map = {
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
-        'non_renderable': {'name': 'nonRenderable', 'default': False},        
-        'is_occluder': {'name': 'occluder', 'default': False},
+        'non_renderable': {'name': 'nonRenderable', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
+        'rendered_in_viewports': {'name': 'renderedInViewports', 'default': True},
+        'is_occluder': {'name': 'occluder', 'default': False},
+        'terrain_decal': {'name': 'terrainDecal', 'default': False},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
+        'fill_volume': {'name': 'name', 'default': False, 'placement': 'IndexedTriangleSet',
+                        'type': 'OVERRIDE', 'override': 'fillVolumeShape'},
+        'double_sided': {'name': 'doubleSided', 'default': False},
+        'material_holder': {'name': 'materialHolder', 'default': False},
         'nav_mesh_mask': {'name': 'buildNavMeshMask', 'default': '0', 'type': 'HEX'},
         'decal_layer': {'name': 'decalLayer', 'default': 0},
-        'fill_volume': {'name': 'name', 'default': False, 'placement': 'IndexedTriangleSet',
-                        'type': 'OVERRIDE', 'override': 'fillVolumeShape'}
+        'vertex_compression_range': {'name': 'vertexCompressionRange', 'default': 'auto',
+                                     'placement': 'IndexedTriangleSet'},
     }
 
     casts_shadows: BoolProperty(
@@ -56,16 +58,28 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         default=i3d_map['non_renderable']['default']
     )
 
-    is_occluder: BoolProperty(
-        name="Occluder",
-        description="Is Occluder?",
-        default=i3d_map['is_occluder']['default']
-    )
-
     distance_blending: BoolProperty(
         name="Distance Blending",
         description="Distance Blending",
         default=i3d_map['distance_blending']['default']
+    )
+
+    rendered_in_viewports: BoolProperty(
+        name="Rendered In Viewports",
+        description="Determines if the object is rendered in Giants Editor viewport",
+        default=i3d_map['rendered_in_viewports']['default']
+    )
+
+    is_occluder: BoolProperty(
+        name="Occluder Mesh",
+        description="Is Occluder?",
+        default=i3d_map['is_occluder']['default']
+    )
+
+    terrain_decal: BoolProperty(
+        name="Terrain Decal",
+        description="If checked, the shape will be rendered as a terrain decal",
+        default=i3d_map['terrain_decal']['default']
     )
 
     cpu_mesh: EnumProperty(
@@ -76,6 +90,26 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
             ('256', 'On', "Turns on CPU Mesh")
         ],
         default=i3d_map['cpu_mesh']['default']
+    )
+
+    fill_volume: BoolProperty(
+        name="Fill Volume",
+        description="Check this if the object is meant to be a fill volume, since this requires some special naming of "
+                    "the IndexedTriangleSet in the i3d file.",
+        default=i3d_map['fill_volume']['default']
+    )
+
+    double_sided: BoolProperty(
+        name="Double Sided",
+        description="If checked, the shape will be rendered from both sides",
+        default=i3d_map['double_sided']['default']
+    )
+
+    material_holder: BoolProperty(
+        name="Material Holder",
+        description="Needs to be set if the material of this shape is to be used on any non-standard geometry "
+        "such as GEOMETRY_PARTICLE_SYSTEM or GEOMETRY_FILL_PLANE in order for the shaders to be properly precompiled",
+        default=i3d_map['material_holder']['default']
     )
 
     nav_mesh_mask: StringProperty(
@@ -92,18 +126,31 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         min=0,
     )
 
-    fill_volume: BoolProperty(
-        name="Fill Volume",
-        description="Check this if the object is meant to be a fill volume, since this requires some special naming of "
-                    "the IndexedTriangleSet in the i3d file.",
-        default=i3d_map['fill_volume']['default']
+    vertex_compression_range: EnumProperty(
+        name="Vertex Compression Range",
+        description="Vertex Compression Range",
+        items=[
+            ('auto', 'Auto', "Auto"),
+            ('0.5', '0.5', "0.5"),
+            ('1.0', '1.0', "1.0"),
+            ('2.0', '2.0', "2.0"),
+            ('4.0', '4.0', "4.0"),
+            ('8.0', '8.0', "8.0"),
+            ('16.0', '16.0', "16.0"),
+            ('32.0', '32.0', "32.0"),
+            ('64.0', '64.0', "64.0"),
+            ('128.0', '128.0', "128.0"),
+            ('256.0', '256.0', "256.0"),
+        ],
+        default=i3d_map['vertex_compression_range']['default']
     )
 
     bounding_volume_object: PointerProperty(
         name="Bounding Volume Object",
-        description="The object used to calculate bvCenter and bvRadius. If the bounding volume object shares origin with the original object, then Giants Engine will always ignore the exported values and recalculate them itself",
+        description="Object used to calculate bvCenter and bvRadius. If it shares the origin with the original object, "
+        "Giants Engine ignores exported values and recalculates them.",
         type=bpy.types.Object,
-		)
+    )
 
 
 @register
@@ -128,11 +175,16 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "receive_shadows")
         layout.prop(obj.i3d_attributes, "non_renderable")
         layout.prop(obj.i3d_attributes, "distance_blending")
+        layout.prop(obj.i3d_attributes, "rendered_in_viewports")
         layout.prop(obj.i3d_attributes, "is_occluder")
+        layout.prop(obj.i3d_attributes, "terrain_decal")
         layout.prop(obj.i3d_attributes, "cpu_mesh")
+        layout.prop(obj.i3d_attributes, 'fill_volume')
+        layout.prop(obj.i3d_attributes, "double_sided")
+        layout.prop(obj.i3d_attributes, 'material_holder')
         layout.prop(obj.i3d_attributes, "nav_mesh_mask")
         layout.prop(obj.i3d_attributes, "decal_layer")
-        layout.prop(obj.i3d_attributes, 'fill_volume')
+        layout.prop(obj.i3d_attributes, "vertex_compression_range")
 
 
 @register
@@ -153,7 +205,7 @@ class I3D_IO_PT_shape_bounding_box(Panel):
         obj = bpy.context.active_object.data
 
         row = layout.row()
-        row.prop(obj.i3d_attributes, 'bounding_volume_object')     
+        row.prop(obj.i3d_attributes, 'bounding_volume_object')
 
 
 def register():

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -39,7 +39,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'min_clip_distance': {'name': 'minClipDistance', 'default': 0.0},
         'object_mask': {'name': 'objectMask', 'default': '0', 'type': 'HEX'},
         'rigid_body_type': {'default': 'none'},
-        'lod_distance': {'name': 'lodDistance', 'default': "Enter your LOD Distances if needed."},
+        'lod_distance': {'name': 'lodDistance', 'default': ""},
         'collision': {'name': 'collision', 'default': True},
         'collision_filter_group': {'name': 'collisionFilterGroup', 'default': 'ff', 'type': 'HEX'},
         'collision_filter_mask': {'name': 'collisionFilterMask', 'default': 'ff', 'type': 'HEX'},
@@ -544,7 +544,7 @@ class I3D_IO_PT_object_attributes(Panel):
         i3d_property(layout, i3d_attributes, 'visibility', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
-        i3d_property(layout, i3d_attributes, 'lod_distance', obj)
+        layout.prop(i3d_attributes, 'lod_distance', placeholder="Enter your LOD Distances if needed.")
 
         if obj.type == 'MESH':
             draw_rigid_body_attributes(layout, i3d_attributes)
@@ -569,7 +569,7 @@ class I3D_IO_PT_object_attributes(Panel):
         if panel:
             panel.use_property_split = True
             panel.prop(obj.i3d_mapping, 'is_mapped')
-            panel.prop(obj.i3d_mapping, 'mapping_name')
+            panel.prop(obj.i3d_mapping, 'mapping_name', placeholder="myCube")
 
 
 def draw_rigid_body_attributes(layout, i3d_attributes) -> None:

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -857,6 +857,14 @@ def handle_old_merge_groups(dummy):
                 del obj['i3d_merge_group']
 
 
+@persistent
+def handle_old_reference_paths(dummy):
+    for obj in bpy.data.objects:
+        if obj.type == 'EMPTY' and (path := obj.get('i3d_reference_path')) is not None:
+            obj.i3d_reference.path = path
+            del obj['i3d_reference_path']
+
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
@@ -866,6 +874,7 @@ def register():
     bpy.types.Object.i3d_reference = PointerProperty(type=I3DReferenceData)
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
+    load_post.append(handle_old_reference_paths)
 
 
 def unregister():

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -145,13 +145,6 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         default=i3d_map['collision']['default']
     )
 
-    collision_mask: StringProperty(
-        name="Collision Mask (deprecated)",
-        description="The objects collision mask as a hexadecimal value, "
-        "deprecated in favor of new filter group and mask",
-        default="ff"
-    )
-
     def collision_preset_items(self, _context) -> list[tuple[str, str, str]]:
         return COLLISIONS_ENUM_LIST
 

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -544,16 +544,13 @@ class I3D_IO_PT_object_attributes(Panel):
         i3d_property(layout, i3d_attributes, 'visibility', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
-        layout.prop(i3d_attributes, 'lod_distance', placeholder="Enter your LOD Distances if needed.")
 
         if obj.type == 'MESH':
             draw_rigid_body_attributes(layout, i3d_attributes)
             draw_merge_group_attributes(layout, obj)
 
-        draw_visibility_condition_attributes(layout, i3d_attributes)
-
         if obj.type == 'EMPTY':
-            draw_joint_attributes(layout, i3d_attributes)
+            layout.prop(i3d_attributes, 'lod_distance', placeholder="Enter your LOD Distances if needed.")
 
             header, panel = layout.panel("i3d_reference", default_closed=False)
             header.label(text="Reference File")
@@ -564,12 +561,18 @@ class I3D_IO_PT_object_attributes(Panel):
                 row.enabled = obj.i3d_reference.path != '' and obj.i3d_reference.path.endswith('.i3d')
                 row.prop(obj.i3d_reference, 'runtime_loaded')
 
+            draw_joint_attributes(layout, i3d_attributes)
+
         header, panel = layout.panel("i3d_mapping_attributes", default_closed=False)
         header.label(text="I3D Mapping")
         if panel:
             panel.use_property_split = True
             panel.prop(obj.i3d_mapping, 'is_mapped')
-            panel.prop(obj.i3d_mapping, 'mapping_name', placeholder="myCube")
+            row = panel.row()
+            row.enabled = obj.i3d_mapping.is_mapped
+            row.prop(obj.i3d_mapping, 'mapping_name', placeholder="myCube")
+
+        draw_visibility_condition_attributes(layout, i3d_attributes)
 
 
 def draw_rigid_body_attributes(layout, i3d_attributes) -> None:

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -531,7 +531,7 @@ class I3D_IO_PT_object_attributes(Panel):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        obj = context.active_object
+        obj = context.object
         i3d_attributes = obj.i3d_attributes
 
         i3d_property(layout, i3d_attributes, 'visibility', obj)


### PR DESCRIPTION

- Add new attributes for FS25
- Replaced most panel classes with new layout.panel setup

- Implemented functionality to parse and apply collision rules from XML, including support for:
  - Presets with additional or removed flags (via `withoutFlag`).
  - Rules with direct mask values (`<mask value="X"/>`).
  - Conditional outputs based on `isTrigger` attributes.
- Added a collision preset enum property to the panel for easy user selection.
- Made `apply_rule_to_mask` to handle both list-based and integer mask definitions.
- Made `convert_old_collision_masks` to dynamically apply rules, accounting for presets, groups, and masks.