### PR TITLE
feat(materials): replace surface_render_method with alpha blending property and restructure panels

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -175,7 +175,7 @@ class Material(Node):
 
     def _write_properties(self):
         # Alpha blending
-        if self.blender_material.surface_render_method == 'BLENDED':
+        if self.blender_material.i3d_attributes.alpha_blending:
             self._write_attribute('alphaBlending', True)
 
     def _export_shader_settings(self):

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -19,6 +19,14 @@ shader_unselected_default_text = ''
 shader_no_variation = 'None'
 shader_parameter_max_decimals = 3  # 0-6 per blender properties documentation
 
+valid_types = {
+    'float': 'float',
+    'float1': 'float',
+    'float2': 'float2',
+    'float3': 'float3',
+    'float4': 'float4'
+}
+
 
 def register(cls):
     classes.append(cls)
@@ -100,7 +108,7 @@ class I3DLoadCustomShader(bpy.types.Operator):
 def parameter_element_as_dict(parameter):
     parameter_list = []
 
-    if parameter.attrib['type'] == 'float':
+    if parameter.attrib['type'] in ['float', 'float1']:
         type_length = 1
     elif parameter.attrib['type'] == 'float2':
         type_length = 2
@@ -196,7 +204,7 @@ class I3DLoadCustomShaderVariation(bpy.types.Operator):
                     for parameter in grouped_parameters[group]:
                         param = shader.shader_parameters.add()
                         param.name = parameter['name']
-                        param.type = parameter['type']
+                        param.type = valid_types.get(parameter['type'], None)
                         data = tuple(map(float, parameter['default_value']))
                         if param.type == 'float':
                             param.data_float_1 = data[0]


### PR DESCRIPTION
Replaced `surface_render_method == 'BLENDED'` check with the new `alpha_blending` property in `i3d_attributes`. Restructured material shader panels for (hopefully) improved code readability and future functionality.

Found one limitation (I think) with the new layout panels, all sub panels you make will inherrit value of the "top level" use_property_split. So had to set that to False for now. Even if you add a new use_property_split within the created panels they will still use the top-level one.

Since @LKAMinco doesn't have that much time these days he asked me to do these changes. (#211)