### PR TITLE
feat(shape): add property to control vertex color export for meshes

### DIFF
--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -203,7 +203,7 @@ class IndexedTriangleSet(Node):
 
                 # Add vertex color
                 vertex_color = None
-                if len(mesh.color_attributes):
+                if mesh.i3d_attributes.use_vertex_colors and len(mesh.color_attributes):
                     # Use the active color layer or fallback to the first (GE supports only one layer)
                     color_layer = mesh.color_attributes.active_color or mesh.color_attributes[0]
 

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -105,6 +105,12 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         type=bpy.types.Object,
 		)
 
+    use_vertex_colors: BoolProperty(
+        name="Use Vertex Colors",
+        description="Enable to export vertex colors for this object",
+        default=False
+    )
+
 
 @register
 class I3D_IO_PT_shape_attributes(Panel):
@@ -133,6 +139,7 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(obj.i3d_attributes, "nav_mesh_mask")
         layout.prop(obj.i3d_attributes, "decal_layer")
         layout.prop(obj.i3d_attributes, 'fill_volume')
+        layout.prop(obj.i3d_attributes, 'use_vertex_colors')
 
 
 @register


### PR DESCRIPTION
Previously, vertex colors were always exported if a layer was present. This commit adds a new property to explicitly enable or disable vertex color export, providing better control for users. This prevents unwanted meshes from exporting with vertex colors.


Based on #211 