### PR TITLE
fix(mesh): restrict bounding volume object selection to valid mesh objects

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -101,9 +101,12 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
 
     bounding_volume_object: PointerProperty(
         name="Bounding Volume Object",
-        description="The object used to calculate bvCenter and bvRadius. If the bounding volume object shares origin with the original object, then Giants Engine will always ignore the exported values and recalculate them itself",
+        description="The object used to calculate bvCenter and bvRadius. "
+        "If the bounding volume object shares origin with the original object, "
+        "then Giants Engine will always ignore the exported values and recalculate them itself",
         type=bpy.types.Object,
-		)
+        poll=lambda self, obj: obj.type == 'MESH' and obj is not bpy.context.object
+    )
 
 
 @register


### PR DESCRIPTION
Added a `poll` function to the `bounding_volume_object` property to restrict its selection to mesh objects only. This ensures that only valid objects can be assigned to this property.