### PR TITLE
feat(exporter): skip objects with '_ignore' suffix and their children

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -177,6 +177,11 @@ def _export(i3d: I3D, objects: List[BlenderObject], sort_alphabetical: bool = Tr
 
 
 def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None) -> None:
+    # Check if the object (and its children) should be ignored
+    if obj.name.lower().endswith('_ignore'):
+        logger.info(f"[{obj.name}] ends with '_ignore', skipping export of this object and its children")
+        return
+
     # Special handling of armature nodes, since they are sort of "extra" compared to how other programs like Maya
     # handles bones. So the option for turning them off is provided.
     _parent = parent


### PR DESCRIPTION
Objects with names ending in '_ignore' (+their children) are now excluded from the export process.

Example use case:
When importing an asset (e.g., a light from the game files) that you need to adjust or fit properly before exporting, you can add the light as a child under an empty (e.g., the sharedLight node in vehicle.xml). By renaming the imported light with the '_ignore' suffix, it will be excluded from the export process, ensuring it doesn’t interfere with the final output.

![image](https://github.com/user-attachments/assets/049fb626-5cdb-461b-9f2e-61a6a99731ea)
![image](https://github.com/user-attachments/assets/d5f665e5-6c3c-46ce-bbcd-ed27cd7e9879)

Can also be useful for objects like bounding volumes if you export e.g. active collection and want to keep the bv object within that collection:
![image](https://github.com/user-attachments/assets/58c4ec25-58d7-4d59-b995-c2367f77ff90)