### PR TITLE
feat(lod): migrate LOD distance to FloatVectorProperty

### DIFF
--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -470,13 +470,13 @@ class I3D_IO_PT_object_attributes(Panel):
             child_count = len(obj.children)
             header, panel = layout.panel('i3d_lod_panel', default_closed=True)
             header.label(text="Level of Detail (LOD)")
+            if panel:
+                for i in range(4):
+                    row = panel.row()
+                    row.enabled = i > 0 and child_count > i
+                    row.prop(obj.i3d_attributes, 'lod_distance', index=i, text=f"Level {i}")
 
-            for i in range(4):
-                row = panel.row()
-                row.enabled = i > 0 and child_count > i
-                row.prop(obj.i3d_attributes, 'lod_distance', index=i, text=f"Level {i}")
-
-            panel.prop(obj.i3d_attributes, 'lod_blending')
+                panel.prop(obj.i3d_attributes, 'lod_blending')
 
 
 @register

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -39,6 +39,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         'object_mask': {'name': 'objectMask', 'default': '0', 'type': 'HEX'},
         'rigid_body_type': {'default': 'none'},
         'lod_distance': {'name': 'lodDistance', 'default': (0.0, 0.0, 0.0, 0.0)},
+        'lod_blending': {'name': 'lodBlending', 'default': True},
         'collision': {'name': 'collision', 'default': True},
         'collision_mask': {'name': 'collisionMask', 'default': 'ff', 'type': 'HEX'},
         'compound': {'name': 'compound', 'default': False},
@@ -104,6 +105,12 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         size=4,
         default=i3d_map['lod_distance']['default'],
         min=0.0
+    )
+
+    lod_blending: BoolProperty(
+        name="LOD Blending",
+        description="Enable LOD blending",
+        default=i3d_map['lod_blending']['default']
     )
 
     clip_distance: FloatProperty(
@@ -468,6 +475,9 @@ class I3D_IO_PT_object_attributes(Panel):
                 row = panel.row()
                 row.enabled = i > 0 and child_count > i
                 row.prop(obj.i3d_attributes, 'lod_distance', index=i, text=f"Level {i}")
+
+            panel.prop(obj.i3d_attributes, 'lod_blending')
+
 
 @register
 class I3D_IO_PT_rigid_body_attributes(Panel):

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -918,7 +918,7 @@ class I3D_IO_PT_mapping_bone_attributes(Panel):
 
 
 @persistent
-def check_lod_distance(dummy):
+def handle_old_lod_distances(dummy):
     for obj in bpy.data.objects:
         if obj.type == 'EMPTY' and 'lod_distance' in obj.get('i3d_attributes', {}):
             current_lod = obj['i3d_attributes']['lod_distance']
@@ -958,10 +958,11 @@ def register():
         subtype='FILE_PATH')
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
-    load_post.append(check_lod_distance)
+    load_post.append(handle_old_lod_distances)
 
 
 def unregister():
+    load_post.remove(handle_old_lod_distances)
     load_post.remove(handle_old_merge_groups)
     del bpy.types.Scene.i3dio_merge_groups
     del bpy.types.Object.i3d_reference_path


### PR DESCRIPTION
- Changed LOD distance from StringProperty to FloatVectorProperty for better usability and accuracy.
- Added migration logic to convert old LOD distance values and preserve existing data.
- Implemented validation rules:
  - First LOD distance value is always 0 and cannot be changed.
  - Subsequent values cannot be smaller than the previous ones.
- Improved UI for managing LOD distances in the object attributes panel:
  - Level 0 is always disabled.
  - Levels 1-3 are conditionally enabled based on the number of child objects.