### PR TITLE
fix(binarize): check online access before invoking I3D converter download

### DIFF
--- a/addon/i3dio/ui/addon_preferences.py
+++ b/addon/i3dio/ui/addon_preferences.py
@@ -162,10 +162,15 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        wm = bpy.context.window_manager
+        if not bpy.app.online_access:
+            self.report({'ERROR'},
+                        "Online access is disabled. Enable it in System Preferences to download the I3D Converter.")
+            return {'CANCELLED'}
+
+        wm = context.window_manager
         # Width increased to fit the warning about the download freezing the UI
         return wm.invoke_props_dialog(self, width=350)
-        
+
     def draw(self, context):
         layout = self.layout
         row = layout.row()

--- a/addon/i3dio/ui/addon_preferences.py
+++ b/addon/i3dio/ui/addon_preferences.py
@@ -108,6 +108,12 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
     email: StringProperty(name="Email", default="")
     password: StringProperty(name="Password", default="", subtype="PASSWORD")
 
+    @classmethod
+    def poll(cls, context):
+        cls.poll_message_set("Online access required to download the I3D Converter, "
+                             "enable it in the Blender System Preferences to use this feature!")
+        return bpy.app.online_access
+
     def execute(self, context):
         import re
         from io import BytesIO
@@ -119,7 +125,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         session = Session()
         request = session.post('https://gdn.giants-software.com/index.php', data={'greenstoneX':'1', 'redstoneX':self.email, 'bluestoneX':self.password})
 
-        ## Clear email and password after usage
+        # Clear email and password after usage
         self.email = ""
         self.password = ""
 
@@ -140,7 +146,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         # Request download of Giants I3D Exporter
         download_url = f'https://gdn.giants-software.com/download.php?downloadId={download_id}'
         request = session.get(download_url)
-        
+
         try:
             # Create in-memory zipfile from downloaded content
             zipfile = ZipFile(BytesIO(request.content), 'r')
@@ -153,7 +159,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
             with zipfile.open('io_export_i3d/util/i3dConverter.exe') as zipped_binary, open(binary_path, 'wb') as saved_binary:
                 copyfileobj(zipped_binary, saved_binary)
             # Set I3D Converter Binary path to newly downloaded converter
-            bpy.context.preferences.addons['i3dio'].preferences.i3d_converter_path = str(binary_path)
+            context.preferences.addons['i3dio'].preferences.i3d_converter_path = str(binary_path)
         except (BadZipfile, KeyError, OSError) as e:
             self.report({'WARNING'}, f"The Community I3D Exporter did not succesfully fetch and install the Giants I3D Converter binary! ({e})")
             return {'CANCELLED'}
@@ -162,11 +168,6 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         return {'FINISHED'}
 
     def invoke(self, context, event):
-        if not bpy.app.online_access:
-            self.report({'ERROR'},
-                        "Online access is disabled. Enable it in System Preferences to download the I3D Converter.")
-            return {'CANCELLED'}
-
         wm = context.window_manager
         # Width increased to fit the warning about the download freezing the UI
         return wm.invoke_props_dialog(self, width=350)


### PR DESCRIPTION
After Blender 4.2, the `online_access` property was introduced as part of the extensions feature to prevent unwanted online activity without user consent. This change ensures compliance with Blender's guidelines for handling online access.

https://docs.blender.org/manual/en/latest/advanced/extensions/addons.html#internet-access