### PR TITLE
refactor(mesh): restructure mesh UI

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -28,9 +28,9 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
     i3d_map = {
         'casts_shadows': {'name': 'castsShadows', 'default': False},
         'receive_shadows': {'name': 'receiveShadows', 'default': False},
-        'non_renderable': {'name': 'nonRenderable', 'default': False},        
-        'is_occluder': {'name': 'occluder', 'default': False},
+        'non_renderable': {'name': 'nonRenderable', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
+        'is_occluder': {'name': 'occluder', 'default': False},
         'cpu_mesh': {'name': 'meshUsage', 'default': '0', 'placement': 'IndexedTriangleSet'},
         'nav_mesh_mask': {'name': 'buildNavMeshMask', 'default': '0', 'type': 'HEX'},
         'decal_layer': {'name': 'decalLayer', 'default': 0},
@@ -56,16 +56,16 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         default=i3d_map['non_renderable']['default']
     )
 
-    is_occluder: BoolProperty(
-        name="Occluder",
-        description="Is Occluder?",
-        default=i3d_map['is_occluder']['default']
-    )
-
     distance_blending: BoolProperty(
         name="Distance Blending",
         description="Distance Blending",
         default=i3d_map['distance_blending']['default']
+    )
+
+    is_occluder: BoolProperty(
+        name="Occluder",
+        description="Is Occluder?",
+        default=i3d_map['is_occluder']['default']
     )
 
     cpu_mesh: EnumProperty(
@@ -124,46 +124,29 @@ class I3D_IO_PT_shape_attributes(Panel):
 
     @classmethod
     def poll(cls, context):
-        if context.object is not None:
-            return context.object.type == 'MESH'
+        return context.mesh
 
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        obj = bpy.context.active_object.data
+        mesh = context.mesh
 
-        layout.prop(obj.i3d_attributes, "casts_shadows")
-        layout.prop(obj.i3d_attributes, "receive_shadows")
-        layout.prop(obj.i3d_attributes, "non_renderable")
-        layout.prop(obj.i3d_attributes, "distance_blending")
-        layout.prop(obj.i3d_attributes, "is_occluder")
-        layout.prop(obj.i3d_attributes, "cpu_mesh")
-        layout.prop(obj.i3d_attributes, "nav_mesh_mask")
-        layout.prop(obj.i3d_attributes, "decal_layer")
-        layout.prop(obj.i3d_attributes, 'fill_volume')
-        layout.prop(obj.i3d_attributes, 'use_vertex_colors')
+        layout.prop(mesh.i3d_attributes, "casts_shadows")
+        layout.prop(mesh.i3d_attributes, "receive_shadows")
+        layout.prop(mesh.i3d_attributes, "non_renderable")
+        layout.prop(mesh.i3d_attributes, "distance_blending")
+        layout.prop(mesh.i3d_attributes, "is_occluder")
+        layout.prop(mesh.i3d_attributes, "cpu_mesh")
+        layout.prop(mesh.i3d_attributes, "nav_mesh_mask")
+        layout.prop(mesh.i3d_attributes, "decal_layer")
+        layout.prop(mesh.i3d_attributes, 'fill_volume')
+        layout.prop(mesh.i3d_attributes, 'use_vertex_colors')
 
-
-@register
-class I3D_IO_PT_shape_bounding_box(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = "I3D Bounding Volume"
-    bl_context = 'data'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'MESH'
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = bpy.context.active_object.data
-
-        row = layout.row()
-        row.prop(obj.i3d_attributes, 'bounding_volume_object')     
+        header, panel = layout.panel('i3d_bounding_volume', default_closed=False)
+        header.label(text="I3D Bounding Volume")
+        if panel:
+            panel.prop(mesh.i3d_attributes, 'bounding_volume_object')
 
 
 def register():


### PR DESCRIPTION
Use blender 4.1 layout.panel to move bounding volume class directly into main panel.

Additionally access mesh directly with context.mesh (this will also allow the props to be pinned in the data properties menu, like the rest of the props)