### PR TITLE
refactor(object): restructure object UI

### DIFF
--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -154,13 +154,10 @@ class SceneGraphNode(Node):
             pass
 
     def _add_reference_file(self):
-        if 'i3d_reference_path' not in self.blender_object.keys():
-            return
-        elif self.blender_object.i3d_reference_path == "" or not self.blender_object.i3d_reference_path.endswith('.i3d'):
-            return
-        self.logger.debug(f"Adding reference file")
-        file_id = self.i3d.add_file_reference(self.blender_object.i3d_reference_path)
-        self._write_attribute('referenceId', file_id)
+        if (reference := self.blender_object.i3d_reference) and reference.path and reference.path.endswith('.i3d'):
+            self.logger.debug("Adding reference file")
+            file_id = self.i3d.add_file_reference(reference.path)
+            self._write_attribute('referenceId', file_id)
 
     @property
     @abstractmethod

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -583,7 +583,7 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.separator(type='LINE')
 
         if obj.type == 'EMPTY':
-            draw_reference_file_attributes(layout, obj.i3d_reference_data)
+            draw_reference_file_attributes(layout, obj.i3d_reference)
             draw_level_of_detail_attributes(layout, obj, i3d_attributes)
             draw_joint_attributes(layout, i3d_attributes)
 
@@ -949,7 +949,7 @@ def register():
     bpy.types.Object.i3d_mapping = PointerProperty(type=I3DMappingData)
     bpy.types.Bone.i3d_mapping = PointerProperty(type=I3DMappingData)
     bpy.types.EditBone.i3d_mapping = PointerProperty(type=I3DMappingData)
-    bpy.types.Object.i3d_reference_data = PointerProperty(type=I3DReferenceData)
+    bpy.types.Object.i3d_reference = PointerProperty(type=I3DReferenceData)
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
     load_post.append(handle_old_lod_distances)
@@ -961,7 +961,7 @@ def unregister():
     load_post.remove(handle_old_lod_distances)
     load_post.remove(handle_old_merge_groups)
     del bpy.types.Scene.i3dio_merge_groups
-    del bpy.types.Object.i3d_reference_data
+    del bpy.types.Object.i3d_reference
     del bpy.types.EditBone.i3d_mapping
     del bpy.types.Bone.i3d_mapping
     del bpy.types.Object.i3d_mapping

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -2,8 +2,10 @@ import bpy
 from bpy.types import (
     Panel
 )
-
-from bpy.app.handlers import (persistent, save_pre, load_post)
+from bpy.app.handlers import (
+    persistent,
+    load_post
+)
 
 from bpy.props import (
     StringProperty,
@@ -157,7 +159,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
             ('static', 'Static', "Inanimate object with infinite mass"),
             ('dynamic', 'Dynamic', "Object moves with physics"),
             ('kinematic', 'Kinematic', "Object moves without physics"),
-            ('compoundChild', 'Compound Child', "Uses the collision of the object higher in the hierarchy marked with the 'compound' option")
+            ('compoundChild', 'Compound Child', "Uses the collision of a higher-level object marked as 'compound'")
         ],
         default=i3d_map['rigid_body_type']['default']
     )
@@ -252,35 +254,6 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         max=200
     )
 
-    split_type_presets: EnumProperty(
-        name="Split Type Presets",
-        description="List containing all in-game tree types.",
-        items=[
-            ('0', "Custom / Manual", "Set a custom tree type or just set a tree type manually"),
-            ('1', "Spruce", "Spruce supports wood harvester"),
-            ('2', "Pine", "Pine supports wood harvester"),
-            ('3', "Larch", "Larch supports wood harvester"),
-            ('4', "Birch", "Birch doesn't support wood harvester"),
-            ('5', "Beech", "Beech doesn't support wood harvester"),
-            ('6', "Maple", "Maple doesn't support wood harvester"),
-            ('7', "Oak", "Oak doesn't support wood harvester"),
-            ('8', "Ash", "Ash doesn't support wood harvester"),
-            ('9', "Locust", "Locust doesn't support wood harvester"),
-            ('10', "Mahogany", "Mahogany doesn't support wood harvester"),
-            ('11', "Poplar", "Poplar doesn't support wood harvester"),
-            ('12', "American Elm", "American Elm doesn't support wood harvester"),
-            ('13', "Cypress", "Cypress doesn't support wood harvester"),
-            ('14', "Downy Serviceberry", "Downy Serviceberry doesn't support wood harvester"),
-            ('15', "Pagoda Dogwood", "Pagoda Dogwood doesn't support wood harvester"),
-            ('16', "Shagbark Hickory", "Shagbark Hickory doesn't support wood harvester"),
-            ('17', "Stone Pine", "Stone Pine doesn't support wood harvester"),
-            ('18', "Willow", "Willow doesn't support wood harvester"),
-            ('19', "Olive Tree", "Olive Tree doesn't support wood harvester")
-        ],
-        default='0',
-        update=lambda self, context: setattr(self, 'split_type', int(self.split_type_presets))
-    )
-
     split_uvs: FloatVectorProperty(
         name="Split UVs",
         description="Min U, Min V, Max U, Max V, UV World Scale",
@@ -292,15 +265,14 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
     use_parent: BoolProperty(
         name="Use Parent",
-        description="Can be found at: Attributes -> Visibility Condition",
+        description="Inherits visibility condition attributes from the parent object",
         default=True
     )
 
     minute_of_day_start: IntProperty(
         name="Minute of Day Start",
-        description="The minute of day when visibility is true. "
-                    "8:00 AM = 480 / "
-                    "8:00 PM = 1200",
+        description="The minute of the day when visibility is enabled.\n"
+        "Example: 8:00 AM = 480, 8:00 PM = 1200",
         default=i3d_map['minute_of_day_start']['default'],
         max=1440,
         min=0,
@@ -308,9 +280,8 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
     minute_of_day_end: IntProperty(
         name="Minute of Day End",
-        description="The minute of day when visibility is false. "
-                    "8:00 AM = 480 / "
-                    "8:00 PM = 1200",
+        description="The minute of the day when visibility is disabled.\n"
+        "Example: 8:00 AM = 480, 8:00 PM = 1200",
         default=i3d_map['minute_of_day_end']['default'],
         max=1440,
         min=0,
@@ -318,7 +289,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
     day_of_year_start: IntProperty(
         name="Day of Year Start",
-        description="Day of Year when visibility is true.",
+        description="The day of the year when visibility is enabled",
         default=i3d_map['day_of_year_start']['default'],
         max=365,
         min=0,
@@ -326,7 +297,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
     day_of_year_end: IntProperty(
         name="Day of Year End",
-        description="Day of Year when visibility is false.",
+        description="The day of the year when visibility is disabled",
         default=i3d_map['day_of_year_end']['default'],
         max=365,
         min=0,
@@ -334,43 +305,41 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
     weather_required_mask: StringProperty(
         name="Weather Required Mask (Hex)",
-        description="The weather required mask as a hexadecimal value. "
-                    "Winter = 400 / "
-                    "Winter + Snow = 408",
+        description="Defines the required weather conditions as a hexadecimal value.\n"
+        "Examples: Winter = 400, Winter + Snow = 408",
         default=i3d_map['weather_required_mask']['default']
     )
 
     weather_prevent_mask: StringProperty(
         name="Weather Prevent Mask (Hex)",
-        description="The weather prevent mask as a hexadecimal value. "
-                    "Summer = 100 / "
-                    "Summer + Sun = 101",
+        description="Defines the weather conditions that prevent visibility as a hexadecimal value.\n"
+        "Examples: Summer = 100, Summer + Sun = 101",
         default=i3d_map['weather_prevent_mask']['default']
     )
 
     viewer_spaciality_required_mask: StringProperty(
         name="Viewer Spaciality Required Mask (Hex)",
-        description="The Viewer Spaciality Required Mask as a hexadecimal value.",
+        description="Defines the required viewer spaciality conditions as a hexadecimal value",
         default=i3d_map['viewer_spaciality_required_mask']['default']
     )
 
     viewer_spaciality_prevent_mask: StringProperty(
         name="Viewer Spaciality Prevent Mask (Hex)",
-        description="The Viewer Spaciality Prevent Mask as a hexadecimal value.",
+        description="Defines the viewer spaciality conditions that prevent visibility as a hexadecimal value",
         default=i3d_map['viewer_spaciality_prevent_mask']['default']
     )
 
     render_invisible: BoolProperty(
         name="Render Invisible",
-        description='If set, the object is always rendered and "visibility"'
-        'must be controlled in the shader using the visible shader parameter',
+        description="If enabled, the object is always rendered.\n"
+        "Visibility must be controlled in the shader using the visible shader parameter",
         default=i3d_map['render_invisible']['default']
     )
 
     visible_shader_parameter: FloatProperty(
         name="Visible Shader Parameter",
-        description='This value is applied to the "visibility" shader parameter when the object is visible.'
-        'If conditions are not met, 0 is passed to the shader.',
+        description="Specifies the value applied to the visibility shader parameter when the object is visible.\n"
+        "If conditions are not met, 0 is passed to the shader",
         default=i3d_map['visible_shader_parameter']['default'],
         min=-100,
         max=100
@@ -469,6 +438,110 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
 
 
 @register
+class I3DMergeGroup(bpy.types.PropertyGroup):
+    name: StringProperty(
+        name='Merge Group Name',
+        description='The name of the merge group',
+        default='MergeGroup'
+    )
+
+    root: PointerProperty(
+        name="Merge Group Root Object",
+        description="The object acting as the root for the merge group",
+        type=bpy.types.Object
+    )
+
+
+@register
+class I3DMappingData(bpy.types.PropertyGroup):
+    is_mapped: BoolProperty(
+        name="Add to mapping",
+        description="If checked this object will be mapped to the i3d mapping of the xml file",
+        default=False
+    )
+
+    mapping_name: StringProperty(
+        name="Alternative Name",
+        description="If this is left empty the name of the object itself will be used",
+        default=''
+    )
+
+
+@register
+class I3DReferenceData(bpy.types.PropertyGroup):
+    path: StringProperty(
+        name="Reference Path",
+        description="The path to the .i3d file you want to reference",
+        default='',
+        subtype='FILE_PATH'
+    )
+
+
+SPLIT_TYPE_PRESETS = {
+    "Spruce": {'split_type': 1, 'support_wood_harvester': True},
+    "Pine": {'split_type': 2, 'support_wood_harvester': True},
+    "Larch": {'split_type': 3, 'support_wood_harvester': True},
+    "Birch": {'split_type': 4, 'support_wood_harvester': False},
+    "Beech": {'split_type': 5, 'support_wood_harvester': False},
+    "Maple": {'split_type': 6, 'support_wood_harvester': False},
+    "Oak": {'split_type': 7, 'support_wood_harvester': False},
+    "Ash": {'split_type': 8, 'support_wood_harvester': False},
+    "Locust": {'split_type': 9, 'support_wood_harvester': False},
+    "Mahogany": {'split_type': 10, 'support_wood_harvester': False},
+    "Poplar": {'split_type': 11, 'support_wood_harvester': False},
+    "American Elm": {'split_type': 12, 'support_wood_harvester': False},
+    "Cypress": {'split_type': 13, 'support_wood_harvester': False},
+    "Downy Serviceberry": {'split_type': 14, 'support_wood_harvester': False},
+    "Pagoda Dogwood": {'split_type': 15, 'support_wood_harvester': False},
+    "Shagbark Hickory": {'split_type': 16, 'support_wood_harvester': False},
+    "Stone Pine": {'split_type': 17, 'support_wood_harvester': False},
+    "Willow": {'split_type': 18, 'support_wood_harvester': False},
+    "Olive Tree": {'split_type': 19, 'support_wood_harvester': False}
+}
+
+
+@register
+class I3D_IO_OT_set_split_type_preset(bpy.types.Operator):
+    bl_idname = 'i3dio.set_split_type_preset'
+    bl_label = 'Set Split Type Preset'
+    bl_options = {'INTERNAL'}
+    preset: StringProperty()
+
+    @classmethod
+    def description(cls, _context, properties):
+        preset = SPLIT_TYPE_PRESETS.get(properties.preset, {})
+        support_harvester = preset.get('support_wood_harvester', False)
+        return (f"Set the split type preset to {properties.preset}.\n"
+                f"Supports wood harvester: {'Yes' if support_harvester else 'No'}")
+
+    def execute(self, context):
+        preset = SPLIT_TYPE_PRESETS.get(self.preset, {})
+        i3d_attributes = context.object.i3d_attributes
+        i3d_attributes.split_type = preset['split_type']
+        return {'FINISHED'}
+
+
+@register
+class I3D_IO_MT_split_type_presets(bpy.types.Menu):
+    bl_idname = 'I3D_IO_MT_split_type_presets'
+    bl_label = 'Split Type Presets'
+
+    def draw(self, _context):
+        layout = self.layout
+        row = layout.row(align=False)
+        col1 = row.column(align=True)
+        col2 = row.column(align=True)
+        presets = list(SPLIT_TYPE_PRESETS.keys())
+        middle = len(presets) // 2
+
+        for idx, preset in enumerate(presets):
+            if idx <= middle:
+                col1.operator(I3D_IO_OT_set_split_type_preset.bl_idname, text=preset).preset = preset
+            else:
+                col2.operator(I3D_IO_OT_set_split_type_preset.bl_idname, text=preset).preset = preset
+
+
+@register
 class I3D_IO_PT_object_attributes(Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -481,193 +554,174 @@ class I3D_IO_PT_object_attributes(Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.use_property_split = True
+        layout.use_property_split = False
         layout.use_property_decorate = False
         obj = context.object
+        i3d_attributes = obj.i3d_attributes
 
-        i3d_property(layout, obj.i3d_attributes, 'locked_group', obj)
-        i3d_property(layout, obj.i3d_attributes, 'visibility', obj)
-        i3d_property(layout, obj.i3d_attributes, 'rendered_in_viewports', obj)
-        i3d_property(layout, obj.i3d_attributes, 'clip_distance', obj)
-        i3d_property(layout, obj.i3d_attributes, 'min_clip_distance', obj)
+        box = layout.box()
+        row = box.row(align=True)
+        row.alignment = 'CENTER'
+        row.label(text="I3D Mapping")
+        row = box.row(align=True)
+        row.prop(obj.i3d_mapping, 'is_mapped', text="Add to mapping")
+        row = row.row(align=True)
+        row.enabled = obj.i3d_mapping.is_mapped
+        row.prop(obj.i3d_mapping, 'mapping_name', text="", placeholder="Custom Mapping Name")
+
+        layout.use_property_split = True
+        i3d_property(layout, i3d_attributes, 'locked_group', obj)
+        i3d_property(layout, i3d_attributes, 'visibility', obj)
+        i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
+        i3d_property(layout, i3d_attributes, 'clip_distance', obj)
+        i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
+
+        layout.separator(type='LINE')
+        box = layout.box()
+        box.label(text="Exporter Specific:")
+        box.prop(i3d_attributes, 'exclude_from_export')
+        layout.separator(type='LINE')
 
         if obj.type == 'EMPTY':
-            child_count = len(obj.children)
-            header, panel = layout.panel('i3d_lod_panel', default_closed=True)
-            header.label(text="Level of Detail (LOD)")
-            if panel:
-                for i in range(4):
-                    row = panel.row()
-                    row.enabled = i > 0 and child_count > i
-                    row.prop(obj.i3d_attributes, 'lod_distances', index=i, text=f"Level {i}")
+            draw_reference_file_attributes(layout, obj.i3d_reference_data)
+            draw_level_of_detail_attributes(layout, obj, i3d_attributes)
+            draw_joint_attributes(layout, i3d_attributes)
 
-                panel.prop(obj.i3d_attributes, 'lod_blending')
+        elif obj.type == 'MESH':
+            draw_rigid_body_attributes(layout, i3d_attributes)
+            draw_merge_group_attributes(layout, context)
 
-        layout.prop(obj.i3d_attributes, 'exclude_from_export')
+        draw_visibility_condition_attributes(layout, i3d_attributes)
 
 
-@register
-class I3D_IO_PT_rigid_body_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Rigidbody'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'MESH'
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = bpy.context.active_object
-
-        layout.prop(obj.i3d_attributes, 'rigid_body_type')
-
-        if obj.i3d_attributes.rigid_body_type != 'none':
-            row_compound = layout.row()
-            row_compound.prop(obj.i3d_attributes, 'compound')
-
-            if obj.i3d_attributes.rigid_body_type in ('static', 'compoundChild'):
-                row_compound.enabled = False
-                obj.i3d_attributes.property_unset('compound')
-
-            layout.prop(obj.i3d_attributes, 'collision')
-            layout.prop(obj.i3d_attributes, 'collision_mask')
-            layout.prop(obj.i3d_attributes, 'trigger')
-            layout.prop(obj.i3d_attributes, 'restitution')
-            layout.prop(obj.i3d_attributes, 'static_friction')
-            layout.prop(obj.i3d_attributes, 'dynamic_friction')
-            layout.prop(obj.i3d_attributes, 'linear_damping')
-            layout.prop(obj.i3d_attributes, 'angular_damping')
-            layout.prop(obj.i3d_attributes, 'density')
-            layout.prop(obj.i3d_attributes, 'solver_iteration_count')
-
-            row_split_type_presets = layout.row()
-            row_split_type_presets.prop(obj.i3d_attributes, 'split_type_presets')
-
-            row_split_type = layout.row()
-            row_split_type.prop(obj.i3d_attributes, 'split_type')
-
-            split_uvs_col = layout.column()
-            split_uvs_col.label(text="Split UVs")
-            split_uvs_col.prop(obj.i3d_attributes, "split_uvs", index=0, text="Min U")
-            split_uvs_col.prop(obj.i3d_attributes, "split_uvs", index=1, text="Min V")
-            split_uvs_col.prop(obj.i3d_attributes, "split_uvs", index=2, text="Max U")
-            split_uvs_col.prop(obj.i3d_attributes, "split_uvs", index=3, text="Max V")
-            split_uvs_col.prop(obj.i3d_attributes, "split_uvs", index=4, text="UV World Scale")
-
-            if obj.i3d_attributes.rigid_body_type != 'static':
-                row_split_type.enabled = False
-                row_split_type_presets.enabled = False
-                split_uvs_col.enabled = False
-                obj.i3d_attributes.property_unset('split_type')
-                obj.i3d_attributes.property_unset('split_type_presets')
-                obj.i3d_attributes.property_unset('split_uvs')
-            else:
-                if obj.i3d_attributes.split_type == 0:
-                    split_uvs_col.enabled = False
-                    obj.i3d_attributes.property_unset('split_uvs')
-
-        else:
-            # Reset all properties if rigidbody is disabled (This is easier than doing conditional export for now.
-            # Since properties that are defaulted, wont get exported)
-            obj.i3d_attributes.property_unset('compound')
-            obj.i3d_attributes.property_unset('collision')
-            obj.i3d_attributes.property_unset('collision_mask')
-            obj.i3d_attributes.property_unset('trigger')
-            obj.i3d_attributes.property_unset('restitution')
-            obj.i3d_attributes.property_unset('static_friction')
-            obj.i3d_attributes.property_unset('dynamic_friction')
-            obj.i3d_attributes.property_unset('linear_damping')
-            obj.i3d_attributes.property_unset('angular_damping')
-            obj.i3d_attributes.property_unset('density')
-            obj.i3d_attributes.property_unset('solver_iteration_count')
-            obj.i3d_attributes.property_unset('split_type')
-            obj.i3d_attributes.property_unset('split_type_presets')
-            obj.i3d_attributes.property_unset('split_uvs')
+def unset_properties(i3d_attributes: bpy.types.PropertyGroup, props: tuple) -> None:
+    for prop in props:
+        i3d_attributes.property_unset(prop)
 
 
-@register
-class I3D_IO_PT_visibility_condition_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Visibility Condition'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
+def draw_rigid_body_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.types.PropertyGroup) -> None:
+    UNSET_PROPS = ('compound', 'collision', 'collision_mask', 'trigger', 'restitution', 'static_friction',
+                   'dynamic_friction', 'linear_damping', 'angular_damping', 'density', 'solver_iteration_count',
+                   'split_type', 'split_uvs')
 
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None
+    is_static = i3d_attributes.rigid_body_type == 'static'
+    header, panel = layout.panel('i3d_rigid_body_panel', default_closed=False)
+    header.label(text="Rigidbody")
+    if panel:
+        panel.prop(i3d_attributes, 'rigid_body_type')
 
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
+        if i3d_attributes.rigid_body_type == 'none':
+            unset_properties(i3d_attributes, UNSET_PROPS)
+            return
 
-        obj = context.active_object
-        i3d_attributes = obj.i3d_attributes
-        use_parent = i3d_attributes.use_parent
+        row_compound = panel.row()
+        row_compound.prop(i3d_attributes, 'compound')
+        if i3d_attributes.rigid_body_type in ('static', 'compoundChild'):
+            row_compound.enabled = False
+            i3d_attributes.property_unset('compound')
 
-        row = layout.row()
-        row.prop(i3d_attributes, 'use_parent')
+        panel.prop(i3d_attributes, 'collision')
+        panel.prop(i3d_attributes, 'collision_mask')
+        panel.prop(i3d_attributes, 'trigger')
+        panel.prop(i3d_attributes, 'restitution')
+        panel.prop(i3d_attributes, 'static_friction')
+        panel.prop(i3d_attributes, 'dynamic_friction')
+        panel.prop(i3d_attributes, 'linear_damping')
+        panel.prop(i3d_attributes, 'angular_damping')
+        panel.prop(i3d_attributes, 'density')
+        panel.prop(i3d_attributes, 'solver_iteration_count')
 
-        properties = ['minute_of_day_start', 'minute_of_day_end',
-                      'day_of_year_start', 'day_of_year_end',
-                      'weather_required_mask', 'weather_prevent_mask',
-                      'viewer_spaciality_required_mask', 'viewer_spaciality_prevent_mask',
-                      'render_invisible', 'visible_shader_parameter']
+        # Split Type Panel
+        header, panel = layout.panel('i3d_split_type_panel', default_closed=True)
+        header.label(text="Split Type")
+        header.emboss = 'NONE'
+        header.menu(I3D_IO_MT_split_type_presets.bl_idname, icon='PRESET', text="")
+        header.enabled = is_static
+        if panel:
+            panel.use_property_split = False
+            panel.prop(i3d_attributes, 'split_type')
+            panel.enabled = is_static
+            col = panel.column(align=True)
+            grid_split_uvs = col.grid_flow(row_major=True, columns=2, align=True)
+            grid_split_uvs.prop(i3d_attributes, 'split_uvs', index=0, text="Min U")
+            grid_split_uvs.prop(i3d_attributes, 'split_uvs', index=1, text="Min V")
+            grid_split_uvs.prop(i3d_attributes, 'split_uvs', index=2, text="Max U")
+            grid_split_uvs.prop(i3d_attributes, 'split_uvs', index=3, text="Max V")
+            col.prop(i3d_attributes, 'split_uvs', index=4, text="UV World Scale")
 
-        for prop in properties:
-            row = layout.row()
+            if i3d_attributes.split_type == 0 or not is_static:
+                unset_properties(i3d_attributes, ('split_uvs', 'split_type'))
+                col.enabled = False
+
+
+def draw_visibility_condition_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.types.PropertyGroup) -> None:
+    PROPS = ('minute_of_day_start', 'minute_of_day_end', 'day_of_year_start', 'day_of_year_end',
+             'weather_required_mask', 'weather_prevent_mask', 'viewer_spaciality_required_mask',
+             'viewer_spaciality_prevent_mask', 'render_invisible', 'visible_shader_parameter')
+
+    use_parent = i3d_attributes.use_parent
+    # layout.use_property_split = False
+    header, panel = layout.panel('i3d_visibility_condition_panel', default_closed=True)
+    header.use_property_split = False
+    header.prop(i3d_attributes, 'use_parent', text="Visibility Condition")
+    if panel:
+        panel.use_property_split = True
+        for prop in PROPS:
+            row = panel.row()
             row.prop(i3d_attributes, prop)
             row.enabled = not use_parent
 
-            if use_parent:
-                i3d_attributes.property_unset(prop)
+        if use_parent:
+            unset_properties(i3d_attributes, PROPS)
 
 
-@register
-class I3DMergeGroup(bpy.types.PropertyGroup):
-    name: StringProperty(
-        name='Merge Group Name',
-        description='The name of the merge group',
-        default='MergeGroup'
-    )
+def draw_joint_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.types.PropertyGroup) -> None:
+    PROPS = ('projection', 'projection_distance', 'projection_angle', 'x_axis_drive', 'y_axis_drive',
+             'z_axis_drive', 'drive_position', 'drive_force_limit', 'drive_spring', 'drive_damping',
+             'breakable_joint', 'joint_break_force', 'joint_break_torque')
 
-    root: PointerProperty(
-        name="Merge Group Root Object",
-        description="The object acting as the root for the merge group",
-        type=bpy.types.Object,
-		)
-  
-@register
-class I3D_IO_PT_merge_group_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Merge Group'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
+    header, panel = layout.panel('i3d_joint_panel', default_closed=True)
+    header.use_property_split = False
+    header.prop(i3d_attributes, 'joint')
+    if panel:
+        panel.enabled = i3d_attributes.joint
+        for prop in PROPS:
+            panel.prop(i3d_attributes, prop)
 
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'MESH'
+        if not i3d_attributes.joint:
+            unset_properties(i3d_attributes, PROPS)
 
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = context.object
 
-        row = layout.row(align=True)
-        row.use_property_decorate = False
+def draw_level_of_detail_attributes(layout: bpy.types.UILayout, obj: bpy.types.Object,
+                                    i3d_attributes: bpy.types.PropertyGroup) -> None:
+    header, panel = layout.panel('i3d_lod_panel', default_closed=True)
+    header.label(text="Level of Detail (LOD)")
+    if panel:
+        for i in range(4):
+            row = panel.row()
+            row.enabled = i > 0 and len(obj.children) > i
+            row.prop(i3d_attributes, 'lod_distances', index=i, text=f"Level {i}")
 
+        panel.prop(i3d_attributes, 'lod_blending')
+
+
+def draw_reference_file_attributes(layout: bpy.types.UILayout, i3d_reference: bpy.types.PropertyGroup) -> None:
+    header, panel = layout.panel('i3d_reference_file_panel', default_closed=True)
+    header.label(text="Reference File")
+    if panel:
+        panel.prop(i3d_reference, 'path')
+
+
+def draw_merge_group_attributes(layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
+    obj = context.object
+    header, panel = layout.panel('i3d_merge_group_panel', default_closed=False)
+    header.label(text="Merge Group")
+    if panel:
+        row = panel.row(align=True)
         row.operator('i3dio.choose_merge_group', text="", icon='DOWNARROW_HLT')
 
         col = row.column(align=True)
-        merge_group_index = obj.i3d_merge_group_index 
+        merge_group_index = obj.i3d_merge_group_index
         if merge_group_index == -1:
             col.operator("i3dio.new_merge_group", text="New", icon="ADD")
         else:
@@ -692,7 +746,9 @@ class I3D_IO_OT_choose_merge_group(bpy.types.Operator):
     bl_property = "enum"
 
     def get_enum_options(self, context):
-        merge_groups_item_list = sorted([(str(idx), mg.name, "") for idx,mg in enumerate(context.scene.i3dio_merge_groups)],key=lambda x: x[1])
+        merge_groups_item_list = sorted(
+            [(str(idx), mg.name, "") for idx, mg in enumerate(context.scene.i3dio_merge_groups)], key=lambda x: x[1]
+        )
         return merge_groups_item_list
 
     enum: EnumProperty(items=get_enum_options, name="Items")
@@ -709,10 +765,11 @@ class I3D_IO_OT_choose_merge_group(bpy.types.Operator):
         else:
             print("same mg")
         return {"FINISHED"}
-    
+
     def invoke(self, context, event):
         context.window_manager.invoke_search_popup(self)
         return {"RUNNING_MODAL"}
+
 
 @register
 class I3D_IO_OT_new_merge_group(bpy.types.Operator):
@@ -731,7 +788,7 @@ class I3D_IO_OT_new_merge_group(bpy.types.Operator):
             name = f"{MERGE_GROUP_DEFAULT_NAME}.{count:03d}"
             count += 1
         mg = context.scene.i3dio_merge_groups.add()
-        
+
         mg.name = name
         mg.root = obj
         old_mg_index = obj.i3d_merge_group_index
@@ -739,7 +796,8 @@ class I3D_IO_OT_new_merge_group(bpy.types.Operator):
         if old_mg_index != -1:
             remove_merge_group_if_empty(context, old_mg_index)
         return {'FINISHED'}
-    
+
+
 def remove_merge_group_if_empty(context, mg_index):
     mg_member_count = 0
     objects_in_higher_indexed_merge_groups = []
@@ -755,7 +813,8 @@ def remove_merge_group_if_empty(context, mg_index):
             obj.i3d_merge_group_index -= 1
     else:
         print(f"{mg_member_count} members left in '{context.scene.i3dio_merge_groups[mg_index]}'")
-        
+
+
 @register
 class I3D_IO_OT_remove_from_merge_group(bpy.types.Operator):
     bl_idname = "i3dio.remove_from_merge_group"
@@ -768,6 +827,7 @@ class I3D_IO_OT_remove_from_merge_group(bpy.types.Operator):
         context.object.i3d_merge_group_index = -1
         remove_merge_group_if_empty(context, old_mg_index)
         return {'FINISHED'}
+
 
 @register
 class I3D_IO_OT_select_merge_group_root(bpy.types.Operator):
@@ -783,6 +843,7 @@ class I3D_IO_OT_select_merge_group_root(bpy.types.Operator):
     def execute(self, context):
         context.scene.i3dio_merge_groups[context.object.i3d_merge_group_index].root = context.object
         return {'FINISHED'}
+
 
 @register
 class I3D_IO_OT_select_mg_objects(bpy.types.Operator):
@@ -802,14 +863,15 @@ class I3D_IO_OT_select_mg_objects(bpy.types.Operator):
                 obj.select_set(True)
         return {'FINISHED'}
 
+
 @persistent
 def handle_old_merge_groups(dummy):
     for scene in bpy.data.scenes:
         for obj in scene.objects:
-            if (old_mg := obj.get('i3d_merge_group')) != None:
+            if (old_mg := obj.get('i3d_merge_group')) is not None:
                 group_id = old_mg.get('group_id')
                 is_root = old_mg.get('is_root')
-                if group_id != None and group_id != "":
+                if group_id is not None and group_id != "":
                     if (mg_idx := scene.i3dio_merge_groups.find(group_id)) != -1:
                         mg = scene.i3dio_merge_groups[mg_idx]
                         obj.i3d_merge_group_index = mg_idx
@@ -817,110 +879,9 @@ def handle_old_merge_groups(dummy):
                         mg = scene.i3dio_merge_groups.add()
                         mg.name = group_id
                         obj.i3d_merge_group_index = len(scene.i3dio_merge_groups) - 1
-                    if is_root != None and is_root == 1:
+                    if is_root is not None and is_root == 1:
                         mg.root = obj
                 del obj['i3d_merge_group']
-
-@register
-class I3D_IO_PT_joint_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Joint'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'EMPTY'
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = context.object
-
-        layout.prop(obj.i3d_attributes, 'joint')
-
-        properties = [
-            ('projection',),
-            ('x_axis_drive',),
-            ('y_axis_drive',),
-            ('z_axis_drive',),
-            ('drive_position',),
-            ('projection_distance',),
-            ('projection_angle',),
-            ('drive_force_limit',),
-            ('drive_spring',),
-            ('drive_damping',),
-            ('breakable_joint',),
-            ('joint_break_force',),
-            ('joint_break_torque',)
-        ]
-
-        for prop in properties:
-            row = layout.row()
-            row.prop(obj.i3d_attributes, prop[0])
-            if obj.i3d_attributes.joint is False:
-                row.enabled = False
-                obj.i3d_attributes.property_unset(prop[0])
-
-
-@register
-class I3D_IO_PT_reference_file(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = 'Reference File'
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'EMPTY'
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        layout.prop(context.object, 'i3d_reference_path')
-
-
-@register
-class I3DMappingData(bpy.types.PropertyGroup):
-    is_mapped: BoolProperty(
-        name="Add to mapping",
-        description="If checked this object will be mapped to the i3d mapping of the xml file",
-        default=False
-    )
-
-    mapping_name: StringProperty(
-        name="Alternative Name",
-        description="If this is left empty the name of the object itself will be used",
-        default=''
-    )
-
-
-@register
-class I3D_IO_PT_mapping_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = "I3D Mapping"
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = context.object
-
-        row = layout.row()
-        row.prop(obj.i3d_mapping, 'is_mapped')
-        row = layout.row()
-        row.prop(obj.i3d_mapping, 'mapping_name')
 
 
 @register
@@ -972,6 +933,14 @@ def handle_old_lod_distances(dummy):
                 pass
 
 
+@persistent
+def handle_old_reference_paths(dummy):
+    for obj in bpy.data.objects:
+        if obj.type == 'EMPTY' and (path := obj.get('i3d_reference_path')) is not None:
+            obj.i3d_reference.path = path
+            del obj['i3d_reference_path']
+
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
@@ -980,21 +949,19 @@ def register():
     bpy.types.Object.i3d_mapping = PointerProperty(type=I3DMappingData)
     bpy.types.Bone.i3d_mapping = PointerProperty(type=I3DMappingData)
     bpy.types.EditBone.i3d_mapping = PointerProperty(type=I3DMappingData)
-    bpy.types.Object.i3d_reference_path = StringProperty(
-        name="Reference Path",
-        description="Put the path to the .i3d file you want to reference here",
-        default='',
-        subtype='FILE_PATH')
+    bpy.types.Object.i3d_reference_data = PointerProperty(type=I3DReferenceData)
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
     load_post.append(handle_old_merge_groups)
     load_post.append(handle_old_lod_distances)
+    load_post.append(handle_old_reference_paths)
 
 
 def unregister():
+    load_post.remove(handle_old_reference_paths)
     load_post.remove(handle_old_lod_distances)
     load_post.remove(handle_old_merge_groups)
     del bpy.types.Scene.i3dio_merge_groups
-    del bpy.types.Object.i3d_reference_path
+    del bpy.types.Object.i3d_reference_data
     del bpy.types.EditBone.i3d_mapping
     del bpy.types.Bone.i3d_mapping
     del bpy.types.Object.i3d_mapping


### PR DESCRIPTION
This is part of the messy #225 

If anyone have any better idea on where the props/panels should be placed, let me know 🙈
- Removed all "extra" panel classes and replaced with UIlayout.panel instead
- Updated some property descriptions
- Changed i3d_reference_path to i3d_reference_data (PointerProp) to prepear for what will come with FS25 props
- Replaced split type enum presets with a menu instead and made it similar to a preset menu in the header

<table>
  <tr>
    <td><strong>New object UI with Mesh:</strong></td>
    <td><strong>New object UI with Empty:</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f4b98933-60fd-4451-903a-d68c915dab48" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/88df2de6-93b3-4efb-b8fe-e1969968bf15" width="200"></td>
  </tr>
  <tr>
    <td><strong>Old object UI with Mesh:</strong></td>
    <td><strong>Old object UI with Empty:</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8506eb65-a22f-4fef-be5a-4b85c0dab0ed" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/e3bcbcab-539c-4a9d-af5b-5a1e3cfe2148" width="200"></td>
  </tr>
</table>