### PR TITLE
fix(attributes): resolve merge issue by moving 'rendered in viewports' property to mesh UI

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -62,19 +62,19 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         description="Distance Blending",
         default=i3d_map['distance_blending']['default']
     )
-      
+
     rendered_in_viewports: BoolProperty(
-      name="Rendered In Viewports",
-      description="Determines if the object is rendered in Giants Editor viewport or not",
-      default=i3d_map['rendered_in_viewports']['default']
+        name="Rendered In Viewports",
+        description="Determines if the object is rendered in Giants Editor viewport or not",
+        default=i3d_map['rendered_in_viewports']['default']
     )
-      
+
     is_occluder: BoolProperty(
         name="Occluder",
         description="Is Occluder?",
         default=i3d_map['is_occluder']['default']
     )
-      
+
     cpu_mesh: EnumProperty(
         name="CPU Mesh",
         description="CPU Mesh",
@@ -141,6 +141,7 @@ class I3D_IO_PT_shape_attributes(Panel):
 
         layout.prop(mesh.i3d_attributes, "casts_shadows")
         layout.prop(mesh.i3d_attributes, "receive_shadows")
+        layout.prop(mesh.i3d_attributes, "rendered_in_viewports")
         layout.prop(mesh.i3d_attributes, "non_renderable")
         layout.prop(mesh.i3d_attributes, "distance_blending")
         layout.prop(mesh.i3d_attributes, "is_occluder")

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -565,7 +565,6 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.use_property_split = True
         i3d_property(layout, i3d_attributes, 'locked_group', obj)
         i3d_property(layout, i3d_attributes, 'visibility', obj)
-        i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
 


### PR DESCRIPTION
Corrected a merge conflict where 'rendered in viewports' was left in the object properties but was no longer functional. The property is now properly added to the mesh attributes and displayed in the mesh UI.