### PR TITLE
fix(attributes): add 'object_mask' property to object attributes panel

### DIFF
--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -568,6 +568,7 @@ class I3D_IO_PT_object_attributes(Panel):
         i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
+        i3d_property(layout, i3d_attributes, 'object_mask', obj)
 
         layout.separator(type='LINE')
         box = layout.box()


### PR DESCRIPTION
Seems like it was never added to the UI by the looks of it