### PR TITLE
fix(exporter): implement unused keep_collections_as_transformgroups property

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -210,7 +210,11 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
     # Collections are checked first since these are always exported in some form
     if isinstance(obj, bpy.types.Collection):
         logger.debug(f"[{obj.name}] is a 'Collection'")
-        node = i3d.add_transformgroup_node(obj, _parent)
+        node = None
+        if i3d.settings['keep_collections_as_transformgroups']:
+            node = i3d.add_transformgroup_node(obj, _parent)
+        else:
+            i3d.logger.info(f"[{obj.name}] will be be ignored and its children will be added to nearest parent")
         _process_collection_objects(i3d, obj, node)
         return  # Early return because collections are special
     else:


### PR DESCRIPTION
Is there a reason this wasn't added?