### PR TITLE
fix(mesh): use expand option for cpu_mesh property

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -145,7 +145,7 @@ class I3D_IO_PT_shape_attributes(Panel):
         layout.prop(mesh.i3d_attributes, "non_renderable")
         layout.prop(mesh.i3d_attributes, "distance_blending")
         layout.prop(mesh.i3d_attributes, "is_occluder")
-        layout.prop(mesh.i3d_attributes, "cpu_mesh")
+        layout.prop(mesh.i3d_attributes, "cpu_mesh", expand=True)
         layout.prop(mesh.i3d_attributes, "nav_mesh_mask")
         layout.prop(mesh.i3d_attributes, "decal_layer")
         layout.prop(mesh.i3d_attributes, 'fill_volume')


### PR DESCRIPTION
Instead of going into a enum list to select on or off, it both looks better and is faster to select what you want when the cpu mesh enum property use the expand option.

Before:
![image](https://github.com/user-attachments/assets/034be39c-2efc-4b84-bb45-39bfa89edfca)


After:
![image](https://github.com/user-attachments/assets/9759cfdc-00f5-4210-83fe-3a42b1b4bc09)
