### PR TITLE
feat(merge-children): add support for merge children export

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -272,8 +272,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                 if not obj.children:
                     logger.warning(f"Empty object {obj.name} has no children to merge.")
                     return
-                # Find the first mesh child of the empty object and use that as the parent for the merge children
-                # first_mesh = next((child for child in obj.children if child.type == 'MESH'), None)
+
                 i3d.add_merge_children_node(obj, parent)
                 return  # Return to prevent children from being processed the "normal" way
 

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -270,8 +270,9 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                 logger.debug(f"[{obj.name}] is a 'MergeChildren' object")
                 if obj.children and next((child for child in obj.children if child.type == 'MESH'), None):
                     logger.debug(f"Processing MergeChildren for: {obj.name}")
-                    i3d.add_merge_children_node(obj, _parent)
-                    return  # Return to prevent children from being processed the "normal" way
+                    node = i3d.add_merge_children_node(obj, _parent)
+                    if node is not None:
+                        return  # Return to prevent children from being processed the "normal" way
                 else:
                     logger.warning(f"Empty object {obj.name} has no children to merge. "
                                    "Exporting as a regular TransformGroup instead.")

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -273,8 +273,9 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                     if not obj.children:
                         logger.warning(f"Empty object {obj.name} has no children to merge.")
                         return
-
-                    i3d.add_merge_children_node(obj.children[0], parent)
+                    # Find the first mesh child of the empty object and use that as the parent for the merge children
+                    # first_mesh = next((child for child in obj.children if child.type == 'MESH'), None)
+                    i3d.add_merge_children_node(obj, parent)
                     return  # Early return to prevent children from being processed the "normal" way
 
             node = i3d.add_transformgroup_node(obj, _parent)

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -266,17 +266,16 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
         elif obj.type == 'ARMATURE':
             node = i3d.add_armature(obj, _parent, is_located=True)
         elif obj.type == 'EMPTY':
-            if obj.i3d_merge_children.enabled:
-                if 'MERGE_CHILDREN' in i3d.settings['features_to_export']:
-                    logger.debug(f"Processing MergeChildren for: {obj.name}")
+            if obj.i3d_merge_children.enabled and 'MERGE_CHILDREN' in i3d.settings['features_to_export']:
+                logger.debug(f"Processing MergeChildren for: {obj.name}")
 
-                    if not obj.children:
-                        logger.warning(f"Empty object {obj.name} has no children to merge.")
-                        return
-                    # Find the first mesh child of the empty object and use that as the parent for the merge children
-                    # first_mesh = next((child for child in obj.children if child.type == 'MESH'), None)
-                    i3d.add_merge_children_node(obj, parent)
-                    return  # Early return to prevent children from being processed the "normal" way
+                if not obj.children:
+                    logger.warning(f"Empty object {obj.name} has no children to merge.")
+                    return
+                # Find the first mesh child of the empty object and use that as the parent for the merge children
+                # first_mesh = next((child for child in obj.children if child.type == 'MESH'), None)
+                i3d.add_merge_children_node(obj, parent)
+                return  # Return to prevent children from being processed the "normal" way
 
             node = i3d.add_transformgroup_node(obj, _parent)
             if obj.instance_collection is not None:

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -266,15 +266,15 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
         elif obj.type == 'ARMATURE':
             node = i3d.add_armature(obj, _parent, is_located=True)
         elif obj.type == 'EMPTY':
-            if obj.i3d_merge_children.enabled and 'MERGE_CHILDREN' in i3d.settings['features_to_export']:
-                logger.debug(f"Processing MergeChildren for: {obj.name}")
-
-                if not obj.children:
-                    logger.warning(f"Empty object {obj.name} has no children to merge.")
-                    return
-
-                i3d.add_merge_children_node(obj, parent)
-                return  # Return to prevent children from being processed the "normal" way
+            if 'MERGE_CHILDREN' in i3d.settings['features_to_export'] and obj.i3d_merge_children.enabled:
+                logger.debug(f"[{obj.name}] is a 'MergeChildren' object")
+                if obj.children and next((child for child in obj.children if child.type == 'MESH'), None):
+                    logger.debug(f"Processing MergeChildren for: {obj.name}")
+                    i3d.add_merge_children_node(obj, _parent)
+                    return  # Return to prevent children from being processed the "normal" way
+                else:
+                    logger.warning(f"Empty object {obj.name} has no children to merge. "
+                                   "Exporting as a regular TransformGroup instead.")
 
             node = i3d.add_transformgroup_node(obj, _parent)
             if obj.instance_collection is not None:

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -255,11 +255,23 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
         elif obj.type == 'ARMATURE':
             node = i3d.add_armature(obj, _parent, is_located=True)
         elif obj.type == 'EMPTY':
+            if obj.i3d_merge_children.enabled:
+                if 'MERGE_CHILDREN' in i3d.settings['features_to_export']:
+                    logger.debug(f"Processing MergeChildren for: {obj.name}")
+
+                    if not obj.children:
+                        logger.warning(f"Empty object {obj.name} has no children to merge.")
+                        return
+
+                    i3d.add_merge_children_node(obj.children[0], parent)
+                    return  # Early return to prevent children from being processed the "normal" way
+
             node = i3d.add_transformgroup_node(obj, _parent)
             if obj.instance_collection is not None:
-                logger.debug(f"[{obj.name}] is a collection instance and will be instanced into the 'Empty' object")
-                # This is a collection instance so the children needs to be fetched from the referenced collection and
-                # be 'instanced' as children of the 'Empty' object directly.
+                logger.debug(f"[{obj.name}] is a collection instance and "
+                             "will be instanced into the 'Empty' object")
+                # This is a collection instance so the children needs to be fetched from the referenced
+                # collection and be 'instanced' as children of the 'Empty' object directly.
                 _process_collection_objects(i3d, obj.instance_collection, node)
                 return
         elif obj.type == 'LIGHT':

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -279,8 +279,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
 
             node = i3d.add_transformgroup_node(obj, _parent)
             if obj.instance_collection is not None:
-                logger.debug(f"[{obj.name}] is a collection instance and "
-                             "will be instanced into the 'Empty' object")
+                logger.debug(f"[{obj.name}] is a collection instance and will be instanced into the 'Empty' object")
                 # This is a collection instance so the children needs to be fetched from the referenced
                 # collection and be 'instanced' as children of the 'Empty' object directly.
                 _process_collection_objects(i3d, obj.instance_collection, node)

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -89,6 +89,17 @@ class I3D:
 
         return node_to_return
 
+    def add_merge_children_node(self, root_child_object: bpy.types.Object,
+                            parent: Optional[SceneGraphNode] = None) -> SceneGraphNode:
+        self.logger.debug(f"Adding MergeChildrenRoot starting with: {root_child_object.name}")
+
+        # Initialize the root node with the first child
+        merge_children_root = self._add_node(MergeChildrenRoot, root_child_object, parent)
+        merge_children_root.add_children_meshes()
+
+        self.logger.info(f"Finished merging children into root: {root_child_object.name}")
+        return merge_children_root
+
     def add_bone(self, bone_object: bpy.types.Bone, parent: Union[SkinnedMeshBoneNode, SkinnedMeshRootNode]) \
             -> SceneGraphNode:
         return self._add_node(SkinnedMeshBoneNode, bone_object, parent)
@@ -146,7 +157,7 @@ class I3D:
         return self._add_node(CameraNode, camera_object, parent)
 
     def add_shape(self, evaluated_mesh: EvaluatedMesh, shape_name: Optional[str] = None, is_merge_group=None,
-                  bone_mapping: ChainMap = None, tangent = False) -> int:
+                  is_generic=None, bone_mapping: ChainMap=None, tangent=False) -> int:
         if shape_name is None:
             name = evaluated_mesh.name
         else:
@@ -155,7 +166,7 @@ class I3D:
         if name not in self.shapes:
             shape_id = self._next_available_id('shape')
             indexed_triangle_set = IndexedTriangleSet(shape_id, self, evaluated_mesh, shape_name, is_merge_group,
-                                                      bone_mapping, tangent)
+                                                      is_generic, bone_mapping, tangent)
             # Store a reference to the shape from both it's name and its shape id
             self.shapes.update(dict.fromkeys([shape_id, name], indexed_triangle_set))
             self.xml_elements['Shapes'].append(indexed_triangle_set.element)
@@ -326,6 +337,7 @@ class I3D:
 from i3dio.node_classes.node import *
 from i3dio.node_classes.shape import *
 from i3dio.node_classes.merge_group import *
+from i3dio.node_classes.merge_children import *
 from i3dio.node_classes.skinned_mesh import *
 from i3dio.node_classes.material import *
 from i3dio.node_classes.file import *

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -101,19 +101,16 @@ class I3D:
         materials_from_children = set()
         for child in empty_object.children:
             if child.type == 'MESH':
-                for material in child.data.materials:
-                    materials_from_children.add(material)
+                materials_from_children.update(child.data.materials)
 
-        # A bit hacky, but we need to create a dummy mesh object to be able to use the ShapeNode class and also to get
-        # materials added to the final shape
+        # Create a merged mesh object to act as a container for the children
+        # This is necessary to utilize the ShapeNode class and include materials
         dummy_mesh_data = bpy.data.meshes.new(f"MergeChildren_{empty_object.name}")
-        self.logger.debug(f"Created dummy mesh data: {dummy_mesh_data.name} "
-                          f"adding {len(materials_from_children)} materials")
         for material in materials_from_children:
             dummy_mesh_data.materials.append(material)
         dummy_mesh_object = bpy.data.objects.new(f"{empty_object.name}_dummy", dummy_mesh_data)
 
-        # Copy the transformation of the original EMPTY
+        # Match the transformation of the original empty object
         dummy_mesh_object.matrix_world = empty_object.matrix_world
         if empty_object.parent is not None:
             dummy_mesh_object.parent = empty_object.parent
@@ -124,6 +121,7 @@ class I3D:
         # Add the children meshes to the root node
         merge_children_root.add_children_meshes(empty_object)
 
+        # Cleanup the temporary dummy object after processing
         bpy.data.objects.remove(dummy_mesh_object, do_unlink=True)
         bpy.data.meshes.remove(dummy_mesh_data, do_unlink=True)
         self.logger.info(f"Finished merging children into root: {empty_object.name}")

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -126,6 +126,16 @@ class I3D:
             dummy_mesh_object.parent = empty_object.parent
             dummy_mesh_object.matrix_parent_inverse = empty_object.matrix_world.inverted()
 
+        first_mesh_child = next(child for child in empty_object.children if child.type == 'MESH')
+
+        def copy_custom_properties(source, target):
+            for key in source.keys():
+                self.logger.debug(f"Copying custom property: {key}")
+                target[key] = source[key]
+
+        copy_custom_properties(first_mesh_child, dummy_mesh_object)
+        copy_custom_properties(first_mesh_child.data.i3d_attributes, dummy_mesh_data.i3d_attributes)
+
         # Initialize the root node with the dummy mesh object
         merge_children_root = self._add_node(MergeChildrenRoot, dummy_mesh_object, parent)
         # Add the children meshes to the root node

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -1,0 +1,40 @@
+from typing import Optional
+import bpy
+import mathutils
+
+from .node import SceneGraphNode
+from .shape import (ShapeNode, EvaluatedMesh)
+from ..i3d import I3D
+
+MERGE_CHILDREN_DIVIDER = 32768
+
+
+class MergeChildrenRoot(ShapeNode):
+    def __init__(self, id_: int, merge_children_object: bpy.types.Object, i3d: I3D,
+                 parent: Optional[SceneGraphNode] = None):
+        self.merge_children_name = f"MergeChildren_{merge_children_object.name}"
+        name = merge_children_object.parent.name
+        super().__init__(id_=id_, shape_object=merge_children_object, i3d=i3d, parent=parent, custom_name=name)
+
+    def add_shape(self):
+        """Override to add the merged mesh as the shape."""
+        self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), self.merge_children_name,
+                                           is_generic=True, tangent=self.tangent)
+        self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
+
+    def add_children_meshes(self):
+        """Collect and evaluate all mesh children starting from the root child."""
+        root = self.blender_object.parent
+        freeze_translation = root.i3d_merge_children.freeze_translation
+        freeze_rotation = root.i3d_merge_children.freeze_rotation
+        freeze_scale = root.i3d_merge_children.freeze_scale
+
+        reference_frame = self.blender_object.matrix_world
+
+        for i, sibling in enumerate(self.blender_object.parent.children):
+            if sibling != self.blender_object and sibling.type == 'MESH':  # Skip the "root" object already added
+                g_value = i / MERGE_CHILDREN_DIVIDER
+                self.logger.debug(f"Sibling mesh: {sibling.name} with generic value: {g_value}")
+                self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
+                    EvaluatedMesh(self.i3d, sibling, reference_frame=reference_frame), g_value)
+                self.logger.debug(f"Collected sibling mesh: {sibling.name}")

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -5,7 +5,12 @@ from .node import SceneGraphNode
 from .shape import (ShapeNode, EvaluatedMesh)
 from ..i3d import I3D
 
-MERGE_CHILDREN_DIVIDER = 32768
+# Maximum index value for `mergeChildren` objects, used to normalize
+# generic values (g_value) for shaders. This constant is critical for:
+# - Calculating normalized indices for motion paths or animations (e.g., vertex animation textures).
+# - Controlling visibility of elements via the `hideByIndex` shader parameter.
+# NOTE: The value must match the expected range in the shaders (e.g., [0..32767]).
+MERGE_CHILDREN_MAX_INDEX = 32767
 
 
 class MergeChildrenRoot(ShapeNode):
@@ -23,27 +28,35 @@ class MergeChildrenRoot(ShapeNode):
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
     def add_children_meshes(self, empty_object: bpy.types.Object):
-        """Collect and evaluate all child meshes of the empty object"""
+        """
+        Collect and evaluate all child meshes of the empty object (mergeChildren root).
+
+        Each child mesh is assigned a normalized `generic_value`, which is used
+        in shaders for animations or visibility controls. Transforms can be
+        baked into the mesh or preserved based on the `apply_transforms` setting.
+        """
         apply_child_transforms = empty_object.i3d_merge_children.apply_transforms
         root_world_matrix = empty_object.matrix_world
         interpolation_steps = empty_object.i3d_merge_children.interpolation_steps
 
         self.logger.debug(
-            f"Collecting children meshes for {empty_object.name}, with {interpolation_steps} interpolation steps."
+            f"Starting collection of child meshes for '{empty_object.name}'. "
+            f"Interpolation steps: {interpolation_steps}."
         )
 
         child_meshes = (child for child in empty_object.children if child.type == 'MESH')
 
         g_value_index = 0
         for child in child_meshes:
-            generic_value = g_value_index / MERGE_CHILDREN_DIVIDER
+            generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX
             self.logger.debug(f"Processing child: '{child.name}', g_value: {generic_value}")
 
             # Use root_matrix to bake transforms into the mesh, or preserve the child's local transform.
             reference_frame = root_world_matrix if apply_child_transforms else child.matrix_world
 
             self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
-                EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), generic_value)
+                EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), generic_value
+            )
 
             g_value_index += interpolation_steps
 

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -13,7 +13,7 @@ class MergeChildrenRoot(ShapeNode):
     def __init__(self, id_: int, merge_children_object: bpy.types.Object, i3d: I3D,
                  parent: Optional[SceneGraphNode] = None):
         self.merge_children_name = f"MergeChildren_{merge_children_object.name}"
-        name = merge_children_object.parent.name
+        name = merge_children_object.name
         super().__init__(id_=id_, shape_object=merge_children_object, i3d=i3d, parent=parent, custom_name=name)
 
     def add_shape(self):
@@ -22,19 +22,70 @@ class MergeChildrenRoot(ShapeNode):
                                            is_generic=True, tangent=self.tangent)
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
-    def add_children_meshes(self):
+    def add_children_meshes(self, empty_object: bpy.types.Object):
         """Collect and evaluate all mesh children starting from the root child."""
-        root = self.blender_object.parent
-        freeze_translation = root.i3d_merge_children.freeze_translation
-        freeze_rotation = root.i3d_merge_children.freeze_rotation
-        freeze_scale = root.i3d_merge_children.freeze_scale
+        self.logger.debug(f"Collecting children meshes for {self.blender_object.name}")
+        self.logger.debug(f"Root object: {empty_object.name}")
+        freeze_translation = empty_object.i3d_merge_children.freeze_translation
+        freeze_rotation = empty_object.i3d_merge_children.freeze_rotation
+        freeze_scale = empty_object.i3d_merge_children.freeze_scale
 
-        reference_frame = self.blender_object.matrix_world
+        from mathutils import Matrix
 
-        for i, sibling in enumerate(self.blender_object.parent.children):
-            if sibling != self.blender_object and sibling.type == 'MESH':  # Skip the "root" object already added
+        for i, child in enumerate(empty_object.children):
+            if child.type == 'MESH':
                 g_value = i / MERGE_CHILDREN_DIVIDER
-                self.logger.debug(f"Sibling mesh: {sibling.name} with generic value: {g_value}")
+
+                # Freeze transformations where they currently are located in the world
+                if any([freeze_translation, freeze_rotation, freeze_scale]):
+                    self.logger.debug(f"Freeze settings: {freeze_translation}, {freeze_rotation}, {freeze_scale}")
+                
+                    # Decompose matrices
+                    child_matrix = child.matrix_world
+                    root_matrix = empty_object.matrix_world
+
+                    self.logger.debug(f"Child translation: {child_matrix.translation}")
+
+                    # Start with an identity matrix
+                    reference_frame = Matrix.Identity(4)
+
+                    # Apply transformations conditionally
+                    if freeze_translation:
+                        reference_frame.translation = root_matrix.translation
+                    else:
+                        reference_frame.translation = child_matrix.translation
+
+                    if freeze_rotation:
+                        # Apply only the rotation part from the root matrix
+                        reference_frame @= root_matrix.to_3x3().to_4x4()
+                    else:
+                        # Apply only the rotation part from the child's matrix
+                        reference_frame @= child_matrix.to_3x3().to_4x4()
+
+                    if freeze_scale:
+                        # Apply only the scale part from the root matrix
+                        scale_matrix = Matrix.Diagonal(root_matrix.to_scale()).to_4x4()
+                    else:
+                        # Apply only the scale part from the child's matrix
+                        scale_matrix = Matrix.Diagonal(child_matrix.to_scale()).to_4x4()
+
+                    # Scale should be applied first, so prepend it
+                    reference_frame = scale_matrix @ reference_frame
+                    self.logger.debug(f"Freezed transformations, translation is: {reference_frame.translation}")
+                else:
+                    # When not freezing transformations, the reference frame is the child's matrix_world and the child
+                    # will end up with same transformations as the root
+                    self.logger.debug("Didn't freeze any transformations")
+                    reference_frame = child.matrix_world
+
+                self.logger.debug(f"child mesh: {child.name} with generic value: {g_value}")
                 self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
-                    EvaluatedMesh(self.i3d, sibling, reference_frame=reference_frame), g_value)
-                self.logger.debug(f"Collected sibling mesh: {sibling.name}")
+                    EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), g_value)
+                self.logger.debug(f"Collected child mesh: {child.name}")
+
+                # Correct matrix reset for all transformations:
+                # reference_frame = child.matrix_world @ empty_object.matrix_world @ empty_object.matrix_world.inverted()
+
+    def populate_xml_element(self):
+        self.logger.debug("Populating XML element for MergeChildrenRoot")
+        super().populate_xml_element()

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -24,34 +24,28 @@ class MergeChildrenRoot(ShapeNode):
 
     def add_children_meshes(self, empty_object: bpy.types.Object):
         """Collect and evaluate all child meshes of the empty object"""
-        apply_transforms = empty_object.i3d_merge_children.apply_transforms
-        root_matrix = empty_object.matrix_world
+        apply_child_transforms = empty_object.i3d_merge_children.apply_transforms
+        root_world_matrix = empty_object.matrix_world
         interpolation_steps = empty_object.i3d_merge_children.interpolation_steps
 
-        self.logger.debug(f"Collecting children meshes for {empty_object.name}, "
-                          f"with {interpolation_steps} interpolation steps.")
+        self.logger.debug(
+            f"Collecting children meshes for {empty_object.name}, with {interpolation_steps} interpolation steps."
+        )
 
-        child_meshes = [child for child in empty_object.children if child.type == 'MESH']
+        child_meshes = (child for child in empty_object.children if child.type == 'MESH')
 
-        g_increase = 0
+        g_value_index = 0
         for child in child_meshes:
-            g_value = g_increase / MERGE_CHILDREN_DIVIDER
-            self.logger.debug(f"Child object: {child.name} (g={g_value}), interpolation steps: {interpolation_steps}")
+            generic_value = g_value_index / MERGE_CHILDREN_DIVIDER
+            self.logger.debug(f"Processing child: '{child.name}', g_value: {generic_value}")
 
-            if apply_transforms:
-                # Bake the child's entire transform (location, rotation, scale) into its mesh data.
-                # In the exported file, the child will no longer have any local transform relative to the root object,
-                # and it will appear as it has been directly aligned with the root's transform.
-                reference_frame = root_matrix
-            else:
-                # Preserve the child's local transform (location, rotation, scale) as it is in Blender.
-                # In the exported file, the child will maintain the same relative position, orientation and scale
-                # to the root object as seen in Blender.
-                reference_frame = child.matrix_world
+            # Use root_matrix to bake transforms into the mesh, or preserve the child's local transform.
+            reference_frame = root_world_matrix if apply_child_transforms else child.matrix_world
 
             self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
-                EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), g_value)
-            g_increase += interpolation_steps
+                EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), generic_value)
+
+            g_value_index += interpolation_steps
 
     def populate_xml_element(self):
         self.logger.debug("Populating XML element for MergeChildrenRoot")

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import bpy
-import mathutils
 
 from .node import SceneGraphNode
 from .shape import (ShapeNode, EvaluatedMesh)
@@ -12,79 +11,47 @@ MERGE_CHILDREN_DIVIDER = 32768
 class MergeChildrenRoot(ShapeNode):
     def __init__(self, id_: int, merge_children_object: bpy.types.Object, i3d: I3D,
                  parent: Optional[SceneGraphNode] = None):
-        self.merge_children_name = f"MergeChildren_{merge_children_object.name}"
         name = merge_children_object.name
+        if merge_children_object.name.endswith('_dummy'):
+            name = merge_children_object.name.replace('_dummy', '')
         super().__init__(id_=id_, shape_object=merge_children_object, i3d=i3d, parent=parent, custom_name=name)
 
     def add_shape(self):
         """Override to add the merged mesh as the shape."""
-        self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), self.merge_children_name,
-                                           is_generic=True, tangent=self.tangent)
+        self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), is_generic=True,
+                                           tangent=self.tangent)
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
     def add_children_meshes(self, empty_object: bpy.types.Object):
-        """Collect and evaluate all mesh children starting from the root child."""
-        self.logger.debug(f"Collecting children meshes for {self.blender_object.name}")
-        self.logger.debug(f"Root object: {empty_object.name}")
-        freeze_translation = empty_object.i3d_merge_children.freeze_translation
-        freeze_rotation = empty_object.i3d_merge_children.freeze_rotation
-        freeze_scale = empty_object.i3d_merge_children.freeze_scale
+        """Collect and evaluate all child meshes of the empty object"""
+        apply_transforms = empty_object.i3d_merge_children.apply_transforms
+        root_matrix = empty_object.matrix_world
+        interpolation_steps = empty_object.i3d_merge_children.interpolation_steps
 
-        from mathutils import Matrix
+        self.logger.debug(f"Collecting children meshes for {empty_object.name}, "
+                          f"with {interpolation_steps} interpolation steps.")
 
-        for i, child in enumerate(empty_object.children):
-            if child.type == 'MESH':
-                g_value = i / MERGE_CHILDREN_DIVIDER
+        child_meshes = [child for child in empty_object.children if child.type == 'MESH']
 
-                # Freeze transformations where they currently are located in the world
-                if any([freeze_translation, freeze_rotation, freeze_scale]):
-                    self.logger.debug(f"Freeze settings: {freeze_translation}, {freeze_rotation}, {freeze_scale}")
-                
-                    # Decompose matrices
-                    child_matrix = child.matrix_world
-                    root_matrix = empty_object.matrix_world
+        g_increase = 0
+        for child in child_meshes:
+            g_value = g_increase / MERGE_CHILDREN_DIVIDER
+            self.logger.debug(f"Child object: {child.name} (g={g_value}), interpolation steps: {interpolation_steps}")
 
-                    self.logger.debug(f"Child translation: {child_matrix.translation}")
+            if apply_transforms:
+                # Bake the child's entire transform (location, rotation, scale) into its mesh data.
+                # In the exported file, the child will no longer have any local transform relative to the root object,
+                # and it will appear as it has been directly aligned with the root's transform.
+                reference_frame = root_matrix
+            else:
+                # Preserve the child's local transform (location, rotation, scale) as it is in Blender.
+                # In the exported file, the child will maintain the same relative position, orientation and scale
+                # to the root object as seen in Blender.
+                reference_frame = child.matrix_world
 
-                    # Start with an identity matrix
-                    reference_frame = Matrix.Identity(4)
-
-                    # Apply transformations conditionally
-                    if freeze_translation:
-                        reference_frame.translation = root_matrix.translation
-                    else:
-                        reference_frame.translation = child_matrix.translation
-
-                    if freeze_rotation:
-                        # Apply only the rotation part from the root matrix
-                        reference_frame @= root_matrix.to_3x3().to_4x4()
-                    else:
-                        # Apply only the rotation part from the child's matrix
-                        reference_frame @= child_matrix.to_3x3().to_4x4()
-
-                    if freeze_scale:
-                        # Apply only the scale part from the root matrix
-                        scale_matrix = Matrix.Diagonal(root_matrix.to_scale()).to_4x4()
-                    else:
-                        # Apply only the scale part from the child's matrix
-                        scale_matrix = Matrix.Diagonal(child_matrix.to_scale()).to_4x4()
-
-                    # Scale should be applied first, so prepend it
-                    reference_frame = scale_matrix @ reference_frame
-                    self.logger.debug(f"Freezed transformations, translation is: {reference_frame.translation}")
-                else:
-                    # When not freezing transformations, the reference frame is the child's matrix_world and the child
-                    # will end up with same transformations as the root
-                    self.logger.debug("Didn't freeze any transformations")
-                    reference_frame = child.matrix_world
-
-                self.logger.debug(f"child mesh: {child.name} with generic value: {g_value}")
-                self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
-                    EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), g_value)
-                self.logger.debug(f"Collected child mesh: {child.name}")
-
-                # Correct matrix reset for all transformations:
-                # reference_frame = child.matrix_world @ empty_object.matrix_world @ empty_object.matrix_world.inverted()
+            self.i3d.shapes[self.shape_id].append_from_evaluated_mesh_generic(
+                EvaluatedMesh(self.i3d, child, reference_frame=reference_frame), g_value)
+            g_increase += interpolation_steps
 
     def populate_xml_element(self):
         self.logger.debug("Populating XML element for MergeChildrenRoot")

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -91,12 +91,16 @@ class SceneGraphNode(Node):
                  blender_object: [bpy.types.Object, bpy.types.Collection, None],
                  i3d: I3D,
                  parent: Union[SceneGraphNode, None] = None,
+                 custom_name: str = None,
                  ):
         self.children = []
         self.blender_object = blender_object
         self.xml_elements: Dict[str, Union[xml_i3d.XML_Element, None]] = {'Node': None}
 
-        self._name = self.blender_object.name
+        if custom_name is not None:
+            self._name = custom_name
+        else:
+            self._name = self.blender_object.name
 
         prefix = i3d.settings.get('object_sorting_prefix', "")
         if prefix and (prefix_index := self._name.find(prefix)) > -1 and prefix_index < len(self._name) - 1:

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -432,9 +432,9 @@ class IndexedTriangleSet(Node):
             xml_i3d.SubElement(self.xml_elements['triangles'], 't', {'vi': "{0} {1} {2}".format(*triangle)})
 
     def populate_xml_element(self):
-        if len(self.evaluated_mesh.mesh.vertices) == 0 and self.is_generic:
+        if len(self.evaluated_mesh.mesh.vertices) == 0 or self.is_generic:
             if self.is_generic:
-                self.logger.debug(f"Initializing dry run for generic merge children root: '{self.name}'")
+                self.logger.debug(f"Setting up generic merge children root: '{self.name}'")
                 self.subsets.append(SubSet())
                 self._write_attribute('count', len(self.subsets), 'subsets')
 
@@ -442,7 +442,7 @@ class IndexedTriangleSet(Node):
                     xml_i3d.SubElement(self.xml_elements['subsets'], 'Subset', subset.as_dict())
                 return
 
-            self.logger.warning(f"has no vertices! Export of this mesh is aborted.")
+            self.logger.warning("has no vertices! Export of this mesh is aborted.")
             return
         self.populate_from_evaluated_mesh()
         self.logger.debug(f"Has '{len(self.subsets)}' subsets, "

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -52,6 +52,8 @@ class Vertex:
 
     def _make_hash_string(self):
         self._str = f"{self._subset_idx}{self._position}{self._normal}{self._vertex_color}"
+        if self._generic_value is not None:
+            self._str += f"{self._generic_value}"
 
         for uv in self._uvs:
             self._str += f"{uv}"
@@ -233,6 +235,8 @@ class IndexedTriangleSet(Node):
                     generic_layer = mesh.attributes["generic"]
                     generic_vertex_index = mesh.loops[loop_index].vertex_index
                     generic_value = generic_layer.data[generic_vertex_index].value
+                elif self.is_generic:
+                    generic_value = self.generic_value
 
                 # Add uvs
                 uvs = []
@@ -435,11 +439,7 @@ class IndexedTriangleSet(Node):
             if self.is_merge_group:
                 vertex_attributes['bi'] = str(self.bind_index)
             elif self.is_generic:
-                if self.is_generic_from_geometry_nodes:
-                    generic_value = vertex.generic_value_for_xml()
-                else:
-                    generic_value = self.generic_value
-                vertex_attributes['g'] = str(generic_value)
+                vertex_attributes['g'] = str(vertex.generic_value_for_xml())
             elif self.bone_mapping is not None:
                 vertex_attributes['bw'] = vertex.blend_weights_for_xml()
                 vertex_attributes['bi'] = vertex.blend_ids_for_xml()

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -102,24 +102,20 @@ class EvaluatedMesh:
                                                   {'object_name': self.name})
         self.generate_evaluated_mesh(mesh_object, reference_frame)
 
-    def generate_evaluated_mesh(self, mesh_object: bpy.types.Object, reference_frame: mathutils.Matrix = None):
+    def generate_evaluated_mesh(self, mesh_object: bpy.types.Object, reference_frame: mathutils.Matrix = None) -> None:
         if self.i3d.get_setting('apply_modifiers'):
             self.object = mesh_object.evaluated_get(self.i3d.depsgraph)
-            self.logger.debug(f"is exported with modifiers applied")
+            self.logger.debug("is exported with modifiers applied")
         else:
             self.object = mesh_object
-            self.logger.debug(f"is exported without modifiers applied")
+            self.logger.debug("is exported without modifiers applied")
 
         self.mesh = self.object.to_mesh(preserve_all_data_layers=False, depsgraph=self.i3d.depsgraph)
 
         # If a reference is given transform the generated mesh by that frame to place it somewhere else than center of
         # the mesh origo
         if reference_frame is not None:
-            self.logger.debug("applying reference frame inside generate_evaluated_mesh in EvaluatedMesh")
-            self.logger.debug(f"translation for reference frame: {reference_frame.translation}, translation for object: {self.object.matrix_world.to_translation()}")
             self.mesh.transform(reference_frame.inverted() @ self.object.matrix_world)
-            after = reference_frame.inverted() @ self.object.matrix_world
-            self.logger.debug(f"translation for object after applying reference frame: {after.to_translation()}")
 
         conversion_matrix = self.i3d.conversion_matrix
         if self.i3d.get_setting('apply_unit_scale'):

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -294,7 +294,7 @@ class IndexedTriangleSet(Node):
                                 "This will confuse GE and result in the mesh showing up as just a wireframe. "
                                 "Please correct by assigning some weight to all vertices.")
 
-        # self.logger.debug(f"Subset {triangle.material_index} with '{len(subset.triangles)}' triangles and {subset}")
+        self.logger.debug(f"Subset {triangle.material_index} with '{len(subset.triangles)}' triangles and {subset}")
         return subset.first_vertex + subset.number_of_vertices, subset.first_index + subset.number_of_indices
 
     def populate_from_evaluated_mesh(self):

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -463,6 +463,8 @@ class IndexedTriangleSet(Node):
                 self.subsets.append(SubSet())
                 self._write_attribute('count', len(self.subsets), 'subsets')
 
+                self._process_bounding_volume()
+
                 for subset in self.subsets:
                     xml_i3d.SubElement(self.xml_elements['subsets'], 'Subset', subset.as_dict())
                 return
@@ -480,6 +482,13 @@ class IndexedTriangleSet(Node):
         # Subsets
         self._write_attribute('count', len(self.subsets), 'subsets')
 
+        self._process_bounding_volume()
+
+        # Write subsets
+        for subset in self.subsets:
+            xml_i3d.SubElement(self.xml_elements['subsets'], 'Subset', subset.as_dict())
+
+    def _process_bounding_volume(self):
         bounding_volume_object = self.evaluated_mesh.mesh.i3d_attributes.bounding_volume_object
         if bounding_volume_object is not None:
             # Calculate the bounding volume center from the corners of the bounding box
@@ -498,10 +507,6 @@ class IndexedTriangleSet(Node):
             self._write_attribute(
                 "bvRadius", max(bounding_volume_object.dimensions) / 2
             )
-
-        # Write subsets
-        for subset in self.subsets:
-            xml_i3d.SubElement(self.xml_elements['subsets'], 'Subset', subset.as_dict())
 
 
 class ControlVertex:

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -134,10 +134,11 @@ class I3D_IO_OT_export(Operator, ExportHelper):
             ('SKINNED_MESHES', "Skinned Meshes", "Bind meshes to the bones of an armature in i3d. If disabled, "
                                                  "the armature and bone structure will still be exported, "
                                                  "but the meshes wont be bound to it"),
-            ('MERGE_CHILDREN', "Merge Children", "Export children of Merge Children empty object into a merged mesh")
+            ('MERGE_CHILDREN', "Merge Children", "Merge the child objects of empties with Merge Children enabled "
+                                                 "into a single exported mesh")
         ),
         options={'ENUM_FLAG'},
-        default={'MERGE_GROUPS', 'SKINNED_MESHES'},
+        default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN'},
     )
 
     collapse_armatures: BoolProperty(

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -133,7 +133,8 @@ class I3D_IO_OT_export(Operator, ExportHelper):
             ('MERGE_GROUPS', "Merge Groups", "Export merge groups"),
             ('SKINNED_MESHES', "Skinned Meshes", "Bind meshes to the bones of an armature in i3d. If disabled, "
                                                  "the armature and bone structure will still be exported, "
-                                                 "but the meshes wont be bound to it")
+                                                 "but the meshes wont be bound to it"),
+            ('MERGE_CHILDREN', "Merge Children", "Export children of Merge Children empty object into a merged mesh")
         ),
         options={'ENUM_FLAG'},
         default={'MERGE_GROUPS', 'SKINNED_MESHES'},

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -449,23 +449,34 @@ class I3DMergeGroup(bpy.types.PropertyGroup):
 class I3DMergeChildren(bpy.types.PropertyGroup):
     enabled: BoolProperty(
         name="Enable Merge Children",
-        description="If checked this object will be merged with the parent object",
+        description=(
+            "When enabled, this object will serve as the merge root for exporting its child objects. "
+            "All child objects will be merged into this object during the export process."
+        ),
         default=False
     )
-    freeze_translation: BoolProperty(
-        name="Translation",
-        description="If checked the translation of the children will be frozen in place when merged",
+    apply_transforms: bpy.props.BoolProperty(
+        name="Apply Transforms",
+        description=(
+            "If enabled, bake location, rotation, and scale into the mesh, so each child mesh "
+            "keeps its current position and orientation relative to the root (merge children root object). "
+            "If disabled, transform all child meshes to align directly with the root object, "
+            "removing their individual offsets and effectively placing them at the root's location"
+        ),
         default=False
     )
-    freeze_rotation: BoolProperty(
-        name="Rotation",
-        description="If checked the rotation of the children will be frozen in place when merged",
-        default=False
-    )
-    freeze_scale: BoolProperty(
-        name="Scale",
-        description="If checked the scale of the children will be frozen in place when merged",
-        default=False
+    interpolation_steps: bpy.props.IntProperty(
+        name="Interpolation Steps",
+        description=(
+            "Number of extra interpolation steps added between merged child objects. "
+            "Higher values help achieve smoother animations or effects when using "
+            "array textures with shaders (e.g., motion path shader variation). "
+            "Ensure the same number of steps is accounted for in the corresponding texture, "
+            "or unexpected offsets may occur in your setup"
+        ),
+        default=1,
+        min=1,
+        max=10
     )
 
 
@@ -759,10 +770,8 @@ def draw_merge_children_attributes(layout: bpy.types.UILayout, i3d_merge_childre
     header.prop(i3d_merge_children, 'enabled', text="Merge Children")
     if panel:
         panel.enabled = i3d_merge_children.enabled
-        col = panel.column(heading="Freeze")
-        col.prop(i3d_merge_children, 'freeze_translation')
-        col.prop(i3d_merge_children, 'freeze_rotation')
-        col.prop(i3d_merge_children, 'freeze_scale')
+        panel.prop(i3d_merge_children, 'apply_transforms')
+        panel.prop(i3d_merge_children, 'interpolation_steps')
 
 
 @register

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -446,6 +446,30 @@ class I3DMergeGroup(bpy.types.PropertyGroup):
 
 
 @register
+class I3DMergeChildren(bpy.types.PropertyGroup):
+    enabled: BoolProperty(
+        name="Enable Merge Children",
+        description="If checked this object will be merged with the parent object",
+        default=False
+    )
+    freeze_translation: BoolProperty(
+        name="Translation",
+        description="If checked the translation of the children will be frozen in place when merged",
+        default=False
+    )
+    freeze_rotation: BoolProperty(
+        name="Rotation",
+        description="If checked the rotation of the children will be frozen in place when merged",
+        default=False
+    )
+    freeze_scale: BoolProperty(
+        name="Scale",
+        description="If checked the scale of the children will be frozen in place when merged",
+        default=False
+    )
+
+
+@register
 class I3DMappingData(bpy.types.PropertyGroup):
     is_mapped: BoolProperty(
         name="Add to mapping",
@@ -565,7 +589,7 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.use_property_split = True
         i3d_property(layout, i3d_attributes, 'locked_group', obj)
         i3d_property(layout, i3d_attributes, 'visibility', obj)
-        i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
+        # i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
 
@@ -579,6 +603,7 @@ class I3D_IO_PT_object_attributes(Panel):
             draw_reference_file_attributes(layout, obj.i3d_reference)
             draw_level_of_detail_attributes(layout, obj, i3d_attributes)
             draw_joint_attributes(layout, i3d_attributes)
+            draw_merge_children_attributes(layout, obj.i3d_merge_children)
 
         elif obj.type == 'MESH':
             draw_rigid_body_attributes(layout, i3d_attributes)
@@ -728,6 +753,18 @@ def draw_merge_group_attributes(layout: bpy.types.UILayout, context: bpy.types.C
             col.operator('i3dio.new_merge_group', text="", icon='DUPLICATE')
             col = row.column(align=True)
             col.operator('i3dio.remove_from_merge_group', text="", icon='PANEL_CLOSE')
+
+
+def draw_merge_children_attributes(layout: bpy.types.UILayout, i3d_merge_children: bpy.types.PropertyGroup) -> None:
+    header, panel = layout.panel('i3d_merge_children_panel', default_closed=True)
+    header.use_property_split = False
+    header.prop(i3d_merge_children, 'enabled', text="Merge Children")
+    if panel:
+        panel.enabled = i3d_merge_children.enabled
+        col = panel.column(heading="Freeze")
+        col.prop(i3d_merge_children, 'freeze_translation')
+        col.prop(i3d_merge_children, 'freeze_rotation')
+        col.prop(i3d_merge_children, 'freeze_scale')
 
 
 @register
@@ -932,59 +969,6 @@ def handle_old_reference_paths(dummy):
         if obj.type == 'EMPTY' and (path := obj.get('i3d_reference_path')) is not None:
             obj.i3d_reference.path = path
             del obj['i3d_reference_path']
-
-
-@register
-class I3DMergeChildren(bpy.types.PropertyGroup):
-    enabled: BoolProperty(
-        name="Enable Merge Children",
-        description="If checked this object will be merged with the parent object",
-        default=False
-    )
-    freeze_translation: BoolProperty(
-        name="Translation",
-        description="If checked the translation of the children will be frozen in place when merged",
-        default=False
-    )
-    freeze_rotation: BoolProperty(
-        name="Rotation",
-        description="If checked the rotation of the children will be frozen in place when merged",
-        default=False
-    )
-    freeze_scale: BoolProperty(
-        name="Scale",
-        description="If checked the scale of the children will be frozen in place when merged",
-        default=False
-    )
-
-
-@register
-class I3D_IO_PT_merge_children_attributes(Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_label = "Merge Children"
-    bl_context = 'object'
-    bl_parent_id = 'I3D_IO_PT_object_attributes'
-
-    @classmethod
-    def poll(cls, context):
-        return context.object is not None and context.object.type == 'EMPTY'
-
-    def draw_header(self, context):
-        layout = self.layout
-        layout.prop(context.object.i3d_merge_children, 'enabled', text="")
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-        obj = context.object
-
-        col = layout.column(heading="Freeze")
-        col.enabled = obj.i3d_merge_children.enabled
-        col.prop(obj.i3d_merge_children, 'freeze_translation')
-        col.prop(obj.i3d_merge_children, 'freeze_rotation')
-        col.prop(obj.i3d_merge_children, 'freeze_scale')
 
 
 def register():

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -598,10 +598,10 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.separator(type='LINE')
 
         if obj.type == 'EMPTY':
-            draw_reference_file_attributes(layout, obj.i3d_reference)
             draw_level_of_detail_attributes(layout, obj, i3d_attributes)
-            draw_joint_attributes(layout, i3d_attributes)
             draw_merge_children_attributes(layout, obj.i3d_merge_children)
+            draw_reference_file_attributes(layout, obj.i3d_reference)
+            draw_joint_attributes(layout, i3d_attributes)
 
         elif obj.type == 'MESH':
             draw_rigid_body_attributes(layout, i3d_attributes)

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -450,29 +450,29 @@ class I3DMergeChildren(bpy.types.PropertyGroup):
     enabled: BoolProperty(
         name="Enable Merge Children",
         description=(
-            "When enabled, this object will serve as the merge root for exporting its child objects. "
-            "All child objects will be merged into this object during the export process."
+            "Enable this object to act as the merge root for exporting its child objects. "
+            "During export, all child objects will be combined into a single merged object."
         ),
         default=False
     )
     apply_transforms: bpy.props.BoolProperty(
         name="Apply Transforms",
         description=(
-            "If enabled, bake location, rotation, and scale into the mesh, so each child mesh "
-            "keeps its current position and orientation relative to the root (merge children root object). "
-            "If disabled, transform all child meshes to align directly with the root object, "
-            "removing their individual offsets and effectively placing them at the root's location"
+            "Bake location, rotation, and scale into each child mesh. When enabled, child meshes retain their "
+            "current position and orientation relative to the root (merge root object). "
+            "When disabled, child meshes will be transformed to align directly with the root object, "
+            "removing their individual offsets and placing them at the root's location."
         ),
         default=False
     )
     interpolation_steps: bpy.props.IntProperty(
         name="Interpolation Steps",
         description=(
-            "Number of extra interpolation steps added between merged child objects. "
-            "Higher values help achieve smoother animations or effects when using "
-            "array textures with shaders (e.g., motion path shader variation). "
-            "Ensure the same number of steps is accounted for in the corresponding texture, "
-            "or unexpected offsets may occur in your setup"
+            "Number of additional interpolation steps inserted between merged child objects. "
+            "This is useful for creating smoother animations or transitions in shaders "
+            "that utilize array textures (e.g., for motion paths). "
+            "Make sure the corresponding texture accounts for the same number of steps to "
+            "avoid unexpected offsets in the animation or effect."
         ),
         default=1,
         min=1,

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -589,7 +589,7 @@ class I3D_IO_PT_object_attributes(Panel):
         layout.use_property_split = True
         i3d_property(layout, i3d_attributes, 'locked_group', obj)
         i3d_property(layout, i3d_attributes, 'visibility', obj)
-        # i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
+        i3d_property(layout, i3d_attributes, 'rendered_in_viewports', obj)
         i3d_property(layout, i3d_attributes, 'clip_distance', obj)
         i3d_property(layout, i3d_attributes, 'min_clip_distance', obj)
 

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -872,6 +872,59 @@ class I3D_IO_PT_mapping_attributes(Panel):
         row.prop(obj.i3d_mapping, 'mapping_name')
 
 
+@register
+class I3DMergeChildren(bpy.types.PropertyGroup):
+    enabled: BoolProperty(
+        name="Enable Merge Children",
+        description="If checked this object will be merged with the parent object",
+        default=False
+    )
+    freeze_translation: BoolProperty(
+        name="Translation",
+        description="If checked the translation of the children will be frozen in place when merged",
+        default=False
+    )
+    freeze_rotation: BoolProperty(
+        name="Rotation",
+        description="If checked the rotation of the children will be frozen in place when merged",
+        default=False
+    )
+    freeze_scale: BoolProperty(
+        name="Scale",
+        description="If checked the scale of the children will be frozen in place when merged",
+        default=False
+    )
+
+
+@register
+class I3D_IO_PT_merge_children_attributes(Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_label = "Merge Children"
+    bl_context = 'object'
+    bl_parent_id = 'I3D_IO_PT_object_attributes'
+
+    @classmethod
+    def poll(cls, context):
+        return context.object is not None and context.object.type == 'EMPTY'
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.prop(context.object.i3d_merge_children, 'enabled', text="")
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        obj = context.object
+
+        col = layout.column(heading="Freeze")
+        col.enabled = obj.i3d_merge_children.enabled
+        col.prop(obj.i3d_merge_children, 'freeze_translation')
+        col.prop(obj.i3d_merge_children, 'freeze_rotation')
+        col.prop(obj.i3d_merge_children, 'freeze_scale')
+
+
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
@@ -884,10 +937,12 @@ def register():
         default='',
         subtype='FILE_PATH')
     bpy.types.Scene.i3dio_merge_groups = CollectionProperty(type=I3DMergeGroup)
+    bpy.types.Object.i3d_merge_children = PointerProperty(type=I3DMergeChildren)
     load_post.append(handle_old_merge_groups)
 
 def unregister():
     load_post.remove(handle_old_merge_groups)
+    del bpy.types.Object.i3d_merge_children
     del bpy.types.Scene.i3dio_merge_groups
     del bpy.types.Object.i3d_reference_path
     del bpy.types.Object.i3d_mapping


### PR DESCRIPTION
Safe for FS22

This PR introduces support for merged children export in Blender. The new functionality allows users to merge all child meshes of a specified root object (empty object type) into a single mesh. This feature is designed to work with shaders in Farming Simulator that require normalized generic values.

#### Key Features
- **Merge Child Meshes**: Merges all child meshes of a specified root empty object into a single mesh.
- **Unique Normalized Generic Values**: Assigns a unique normalized `generic_value` to each top-level child and its descendants. This is crucial for shaders in Farming Simulator that require normalized generic values.
- **Transform Handling**: Option to apply local transforms to the root’s transform or preserve each mesh's local transform.
- **Interpolation Steps**: Supports interpolation steps for smoother vertex animations. This feature is particularly useful for meshes using shader variations that utilize trackArray (array texture). Ensure the texture has the same interpolation to avoid unexpected results.
- **Shader Compatibility**: Designed to work with shaders in Farming Simulator that use `generic_value` for various effects, such as array textures for position/rotation/scale data or `hideByIndex` parameters for visibility control.

#### Usage
1. Select the root empty object containing the child meshes to be merged.
2. Configure the i3d_merge_children properties, including apply_transforms and interpolation_steps.
3. Run the export process to generate the merged mesh.

#### Additional Notes
- **Shader Integration**: This feature is specifically designed to work with shaders in Farming Simulator that require normalized generic values. For example, array textures can store position/rotation/scale data in each pixel, with each pixel corresponding to the next generic value. This allows for complex setups like caterpillar treaded tracks driven by a shader.
- **Visibility Control**: The `hideByIndex` parameter in shaders can use the generic value to hide/unhide meshes based on their index. For instance, setting `hideByIndex` to 0 will show all all meshes, 1 will hide first child mesh, 2 will also hide second child mesh, 3 will also hide third child mesh and so on.
- **Non-Destructive Workflow**: Users can also use this feature as a way to merge multiple meshes without utilizing the generic value, maintaining a non-destructive workflow.
- **Geometry Nodes Integration**: The generic value can also be exported through geometry nodes. If a geometry nodes setup stores an attribute named "generic," it will be exported as well. This approach allows for setups like caterpillar tread tracks where each piece is assigned its own generic value directly in the target mesh attributes, without requiring a parent empty with merge children enabled.


## hideByInde House Example
<img src="https://github.com/user-attachments/assets/54c3bb13-db8d-45d7-9f0d-6ed3930004f3" width="200">

Since only 1 material is allowed per mesh in FS22, all children meshes need to have the same material assigned
<img src="https://github.com/user-attachments/assets/17cfecb4-9eba-4d4f-89ad-1021ab31a99f" width="200">
<img src="https://github.com/user-attachments/assets/7d2eb84f-13d6-4256-bb2e-2c53bb6e5cc4" width="200">

https://github.com/user-attachments/assets/1e219f9a-9fa8-4943-b8ec-a378f67bb241

## motionPath Track Example
<img src="https://github.com/user-attachments/assets/f12e38ec-aab2-40bb-a53d-b347f7a25f91" width="200">
<img src="https://github.com/user-attachments/assets/ac6ffdc3-e359-400a-af47-71d97e619c4c" width="200">
<img src="https://github.com/user-attachments/assets/178f9b48-0938-4d4b-b2dc-21e27a4b4fe4" width="300">

https://github.com/user-attachments/assets/9a25b70b-1bbe-4ea3-a890-7659f20a4b78



[pullRequest_Examples.zip](https://github.com/user-attachments/files/18526749/pullRequest_Examples.zip)