### PR TITLE
fix(exporter): resolve UI lockout when disabling 'copy_files' property

### DIFF
--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -336,9 +336,11 @@ def export_files(layout, operator):
     if body:
         body.use_property_split = False
         body.prop(operator, 'copy_files')
-        body.prop(operator, 'overwrite_files')
-        body.enabled = operator.copy_files
-        body.prop(operator, 'file_structure')
+        col = body.column()
+        col.enabled = operator.copy_files
+        col.prop(operator, 'overwrite_files')
+        col.alignment = 'RIGHT'
+        col.prop(operator, 'file_structure')
 
 
 def export_debug(layout, operator):


### PR DESCRIPTION
Tiny mistake from #221, when you disabled copy_files, copy_files would also be disabled in the UI.