### PR TITLE
fix(shape): handle empty and unused material slots in IndexedTriangleSet

### DIFF
--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -153,7 +153,7 @@ class I3D:
         return self._add_node(CameraNode, camera_object, parent)
 
     def add_shape(self, evaluated_mesh: EvaluatedMesh, shape_name: Optional[str] = None, is_merge_group=None,
-                  bone_mapping: ChainMap = None, tangent = False) -> int:
+                  bone_mapping: ChainMap = None) -> int:
         if shape_name is None:
             name = evaluated_mesh.name
         else:
@@ -162,7 +162,7 @@ class I3D:
         if name not in self.shapes:
             shape_id = self._next_available_id('shape')
             indexed_triangle_set = IndexedTriangleSet(shape_id, self, evaluated_mesh, shape_name, is_merge_group,
-                                                      bone_mapping, tangent)
+                                                      bone_mapping)
             # Store a reference to the shape from both it's name and its shape id
             self.shapes.update(dict.fromkeys([shape_id, name], indexed_triangle_set))
             self.xml_elements['Shapes'].append(indexed_triangle_set.element)

--- a/addon/i3dio/node_classes/merge_group.py
+++ b/addon/i3dio/node_classes/merge_group.py
@@ -27,7 +27,7 @@ class MergeGroupRoot(ShapeNode):
 
     # Override default shape behaviour to use the merge group mesh name instead of the blender objects name
     def add_shape(self):
-        self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), self.merge_group_name, True, tangent=self.tangent)
+        self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), self.merge_group_name, True)
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
     def add_mergegroup_child(self, child: MergeGroupChild):

--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -214,7 +214,7 @@ class SkinnedMeshShapeNode(ShapeNode):
         # Use a ChainMap to easily combine multiple bone mappings and get around any problems with multiple bones
         # named the same as a ChainMap just gets the bone from the first armature added
         self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object), self.skinned_mesh_name,
-                                           bone_mapping=self.bone_mapping, tangent=self.tangent)
+                                           bone_mapping=self.bone_mapping)
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
     def populate_xml_element(self):


### PR DESCRIPTION
- Fixed an exporter error caused by an extra, unused material slot (with assigned material).
- Fixed a crash when self.i3d.add_material encountered an empty material slot.
- Centralized material handling in populate_from_evaluated_mesh, ensuring all material-related issues are handled in one place.

Tested this change with various blend files, with and without textures, with merge groups, skinned meshes etc etc.

I noticed this randomly because I had accidentally added a extra material to my mesh and that material was not assigned to any triangles. Which then caused a error in the last debug logging inside process_subset function. I then also noticed that original code in ShapeNode populate_xml_element would also add these unused materials + even try to add empty material slots to self.i3d.add_material which also ended up with an error.

So now this mess will export correctly, first empty material slot will get the default material, then the green materials will be exported and the rest will just be ignored with a warning.
![image](https://github.com/user-attachments/assets/60282ed5-d643-4f47-9386-ef3cd4b0474e)
