### PR TITLE
feat(skinned-mesh): move collapse armature property to object level

### DIFF
--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -100,7 +100,7 @@ class SkinnedMeshRootNode(TransformGroupNode):
         self.bones: List[SkinnedMeshBoneNode] = list()
         self.bone_mapping: Dict[str, int] = {}
         self.armature_object = armature_object
-        self.is_collapsed = i3d.settings['collapse_armatures']
+        self.is_collapsed = armature_object.i3d_attributes.collapse_armature
         super().__init__(id_=id_, empty_object=armature_object, i3d=i3d, parent=None if self.is_collapsed else parent)
 
         bone_parent = parent if self.is_collapsed else self
@@ -133,6 +133,9 @@ class SkinnedMeshRootNode(TransformGroupNode):
         if self.parent is None:
             self.parent = parent  # If the armature was created via a modifier, its parent was not set.
 
+        if self.parent is parent and self.parent is not None:
+            return  # Already in the correct hierarchy
+
         if parent is not None:
             parent.add_child(self)
             parent.element.append(self.element)
@@ -142,7 +145,7 @@ class SkinnedMeshRootNode(TransformGroupNode):
         self.i3d.processed_objects[self.blender_object] = self
 
     def add_i3d_mapping_to_xml(self):
-        # Skip exporting i3d mapping if 'collapse_armatures' setting is enabled, because the armature is not exported
+        # Skip exporting i3d mapping if 'collapse_armature' setting is enabled, because the armature is not exported
         if not self.is_collapsed:
             super().add_i3d_mapping_to_xml()
 

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -143,14 +143,6 @@ class I3D_IO_OT_export(Operator, ExportHelper):
         default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN'},
     )
 
-    collapse_armatures: BoolProperty(
-        name="Collapse Armatures",
-        description="If enabled the armature itself will get exported as a transformgroup, "
-                    "where all its bones are organized as children. "
-                    "If not then the armatures parent will be used",
-        default=True
-    )
-
     copy_files: BoolProperty(
         name="Copy Files",
         description="Copies the files to have them together with the i3d file. Structure is determined by 'File "
@@ -222,7 +214,6 @@ class I3D_IO_OT_export(Operator, ExportHelper):
             "alphabetic_uvs",
             "object_types_to_export",
             "features_to_export",
-            "collapse_armatures",
             "copy_files",
             "overwrite_files",
             "file_structure",
@@ -317,7 +308,6 @@ def export_options(layout: bpy.types.UILayout, operator):
         body.prop(operator, 'object_types_to_export', expand=True)
         body.separator(type='LINE')
         body.prop(operator, 'features_to_export', expand=True)
-        body.prop(operator, 'collapse_armatures')
         body.separator(type='LINE')
         body.prop(operator, "axis_forward")
         body.prop(operator, "axis_up")

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -429,6 +429,17 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         default=False
     )
 
+    collapse_armature: BoolProperty(
+        name="Collapse Armature",
+        description=(
+            "If enabled, the armature itself will not be exported. "
+            "Instead, its root bones will take its position in the scene graph. "
+            "If disabled, the armature will be exported as a transform group, "
+            "with bones structured as they appear in Blender."
+        ),
+        default=True
+    )
+
 
 @register
 class I3DMergeGroup(bpy.types.PropertyGroup):
@@ -603,6 +614,8 @@ class I3D_IO_PT_object_attributes(Panel):
         box = layout.box()
         box.label(text="Exporter Specific:")
         box.prop(i3d_attributes, 'exclude_from_export')
+        if obj.type == 'ARMATURE':
+            box.prop(i3d_attributes, 'collapse_armature')
         layout.separator(type='LINE')
 
         if obj.type == 'EMPTY':


### PR DESCRIPTION
- Moved the "Collapse Armature" property from the export panel to individual armature objects.
- Allows per-armature control instead of a global setting.
- Improves flexibility for exporting different armature configurations.


![image](https://github.com/user-attachments/assets/dfa3091f-8f01-473d-b479-e463ee301952)
