### PR TITLE
fix(i3d mapping): support any root element instead of just <vehicle>

### DIFF
--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -307,59 +307,73 @@ class I3D:
             self.export_i3d_mapping()
 
     def export_i3d_mapping(self) -> None:
-        self.logger.info(f"Exporting i3d mappings to {self.settings['i3d_mapping_file_path']}")
-        with open(bpy.path.abspath(self.settings['i3d_mapping_file_path']), 'r+') as xml_file:
-            vehicle_xml = []
-            i3d_mapping_idx = None
-            i3d_mapping_end_found = False
-            for idx,line in enumerate(xml_file):
-                if i3d_mapping_idx is None:
-                    if '<i3dMappings>' in line:
-                        i3d_mapping_idx = idx 
-                        vehicle_xml.append(line)
-                        xml_indentation = line[0:line.find('<')]
-                    
-                if i3d_mapping_idx is None or i3d_mapping_end_found:
-                    vehicle_xml.append(line)
-                
-                if not (i3d_mapping_idx is None or i3d_mapping_end_found):
-                    i3d_mapping_end_found = True if '</i3dMappings>' in line else False
+        file_path = bpy.path.abspath(self.settings['i3d_mapping_file_path'])
+        self.logger.info(f"Exporting i3d mappings to {file_path}")
 
-            if i3d_mapping_idx is None:
-                for i in reversed(range(len(vehicle_xml))):
-                    if vehicle_xml[i].startswith('</vehicle>'):
-                        xml_indentation = ' '*4
-                        vehicle_xml.insert(i, f"\n{xml_indentation}<i3dMappings>\n")
-                        i3d_mapping_idx = i
-                        self.logger.info(f"Vehicle file does not have an <i3dMappings> tag, inserting one above </vehicle> with default indentation")
-                        break
+        # Only use ElementTree for parsing the file, writing is done manually to avoid formatting the entire file
+        tree = xml_i3d.parse(file_path)
+        if tree is None:
+            self.logger.error(f"Failed to parse the XML file: {file_path}")
+            return
+        root = tree.getroot()
+        i3d_mappings_element = root.find('i3dMappings')
 
-            if i3d_mapping_idx is None:
-                self.logger.warning(f"Cannot export i3d mapping, provided file has no <i3dMappings> or root level <vehicle> tag!")
-                return
-            
-            def build_index_string(node_to_index):
-                if node_to_index.parent is None:
-                    index = f"{self.scene_root_nodes.index(node_to_index):d}>"
-                else:
-                    index = build_index_string(node_to_index.parent)
-                    if index[-1] != '>':
-                        index += '|'
-                    index += str(node_to_index.parent.children.index(node_to_index))
-                return index
+        with open(file_path, 'r', encoding='utf-8') as xml_file:
+            lines = xml_file.readlines()
 
-            for mapping_node in self.i3d_mapping:
-                # If the mapping is an empty string, use the node name
-                if not (mapping_name := getattr(mapping_node.blender_object.i3d_mapping, 'mapping_name')):
-                    mapping_name = mapping_node.name
-                
-                vehicle_xml[i3d_mapping_idx] += f'{xml_indentation*2}<i3dMapping id="{mapping_name}" node="{build_index_string(mapping_node)}" />\n'
-                
-            vehicle_xml[i3d_mapping_idx] += f'{xml_indentation}</i3dMappings>\n'
+        i3d_mapping_idx = None
+        closing_root_idx = None
+        xml_indentation = ' ' * 4
+        for idx, line in enumerate(lines):
+            stripped_line = line.strip()  # Remove leading and trailing whitespace
+            if '<i3dMappings>' in stripped_line:
+                i3d_mapping_idx = idx
+                xml_indentation = line[:line.find('<')]  # Preserve indentation
+                break
+            if stripped_line == f"</{root.tag}>":
+                closing_root_idx = idx  # Preserve the index of the closing root tag
 
-            xml_file.seek(0)
-            xml_file.truncate()
-            xml_file.writelines(vehicle_xml)
+        if i3d_mapping_idx is None and closing_root_idx is not None:
+            i3d_mapping_idx = closing_root_idx
+            lines.insert(i3d_mapping_idx, f"\n{xml_indentation}<i3dMappings>\n")
+            self.logger.info(f"Inserted missing <i3dMappings> before </{root.tag}>.")
+
+        if i3d_mapping_idx is None:
+            self.logger.warning("Cannot export i3d mapping. No valid root element found!")
+            return
+
+        def _build_index_string(node_to_index) -> str:
+            if node_to_index.parent is None:  # Root node should end with '>'
+                return f"{self.scene_root_nodes.index(node_to_index)}>"
+            index = _build_index_string(node_to_index.parent)
+            if index[-1] != '>':  # If it's not a root use '|'
+                index += '|'
+            # Add the child index
+            index += str(node_to_index.parent.children.index(node_to_index))
+            return index
+
+        new_mappings = []
+        for mapping_node in self.i3d_mapping:
+            # If the mapping is an empty string, use the node name
+            mapping_name = getattr(mapping_node.blender_object.i3d_mapping, 'mapping_name', '') or mapping_node.name
+            new_mappings.append(
+                f'{xml_indentation*2}<i3dMapping id="{mapping_name}" node="{_build_index_string(mapping_node)}" />\n'
+            )
+
+        # Remove old mappings and insert new ones
+        if i3d_mappings_element is not None:
+            # Remove existing mappings while keeping <i3dMappings> tag
+            end_idx = i3d_mapping_idx
+            while end_idx < len(lines) and '</i3dMappings>' not in lines[end_idx]:
+                end_idx += 1
+            lines[i3d_mapping_idx + 1:end_idx] = new_mappings  # Replace contents
+        else:
+            lines.insert(i3d_mapping_idx + 1, ''.join(new_mappings) + f"{xml_indentation}</i3dMappings>\n")
+
+        with open(file_path, 'w', encoding='utf-8') as xml_file:
+            xml_file.writelines(lines)
+
+        self.logger.info(f"Successfully exported i3dMappings to {file_path}")
 
 # To avoid a circular import, since all nodes rely on the I3D class, but i3d itself contains all the different nodes.
 from i3dio.node_classes.node import *


### PR DESCRIPTION
Updated XML parsing to dynamically detect any root element rather than restricting it to <vehicle>.
With FS25 introducing even more XML structures that support <i3dMappings> compared to FS22,
this ensures broader compatibility.

Also separated reading and writing operations to prevent potential file corruption. Previously, modifying the file in-place could lead to partial overwrites if an error occurred.