### PR TITLE
fix(addon-preferences): ensure I3D Converter path persists and improve UI clarity

### DIFF
--- a/addon/i3dio/ui/addon_preferences.py
+++ b/addon/i3dio/ui/addon_preferences.py
@@ -4,10 +4,11 @@ import pathlib
 import bpy
 from bpy.types import AddonPreferences
 from bpy.props import (StringProperty, EnumProperty, BoolProperty)
+from .. import __package__ as base_package
 
 
 class I3D_IO_AddonPreferences(AddonPreferences):
-    bl_idname = 'i3dio'
+    bl_idname = base_package
 
     fs_data_path: StringProperty(
         name="FS Data Folder",
@@ -15,15 +16,25 @@ class I3D_IO_AddonPreferences(AddonPreferences):
         default=""
     )
 
+    # Blender does not automatically mark add-on preferences as "dirty" when modified through the API (via operators).
+    # This means that changes made programmatically will not be saved when Blender is closed.
+    # The workaround below forces Blender to recognize the preferences as modified,
+    # ensuring that the I3D Converter path persists across Blender sessions.
+    # Related Blender issue: https://projects.blender.org/blender/blender/issues/128505
+    def update_is_dirty(self, context: bpy.types.Context) -> None:
+        context.preferences.is_dirty = True
+
     i3d_converter_path: StringProperty(
-        name="Path To Binary I3D Converter",
-        description="Path to the i3dConverter.exe",
+        name="I3D Converter Path",
+        description=("Path to i3dConverter.exe, required to convert raw I3D files by extracting <Shapes> data "
+                     "and generating an external .shapes file for optimized mesh storage."),
         subtype='FILE_PATH',
-        default=""
+        default="",
+        update=update_is_dirty
     )
 
     general_tabs: EnumProperty(name="Tabs", items=[("GENERAL", "General", "")], default="GENERAL")
-    converter_mode_tabs: EnumProperty(name="Tabs", items=[("MANUAL", "Manual", ""), ("AUTOMATIC", "Automatic", "")], default="MANUAL")
+    converter_mode_tabs: EnumProperty(name="Tabs", items=[("AUTOMATIC", "Automatic", ""), ("MANUAL", "Manual", "")])
 
     def draw(self, context):
         layout = self.layout
@@ -31,28 +42,48 @@ class I3D_IO_AddonPreferences(AddonPreferences):
         col = layout.column(align=True)
         row = col.row()
         row.prop(self, "general_tabs", expand=True)
-
+        col.separator(factor=1.5)
+        col.box().row().prop(self, 'fs_data_path')
+        col.separator(factor=1.5)
         box = col.box()
-        row = box.row()
-        row.prop(self, 'fs_data_path')
+        box.label(text="Binary I3D Converter:")
 
-        c_box = box.box()
-        c_box.label(text="Binary I3D Converter")
-        
-        row = c_box.row()
-        row.prop(self, 'converter_mode_tabs', expand=True)
+        giants_exist = any(addon.bl_info.get("name") == "GIANTS I3D Exporter Tools" for addon in addon_utils.modules())
+        path = pathlib.Path(self.i3d_converter_path)
+        is_path_valid = path.exists() and path.is_file()
+        if not is_path_valid or (giants_exist and not self.i3d_converter_path):
+            info_box = box.box()
+            if not is_path_valid and self.i3d_converter_path != "":
+                info_box.label(text="Invalid I3D Converter path set.", icon="ERROR")
+            else:
+                info_box.label(text="No I3D Converter path set.", icon="INFO")
 
-        match self.converter_mode_tabs:
-            case 'MANUAL':
-                row = c_box.row(align=True)
-                row.prop(self, 'i3d_converter_path')
-                if(next((True for addon in addon_utils.modules() if addon.bl_info.get("name") == "GIANTS I3D Exporter Tools"), False)):
-                    row.operator('i3dio.i3d_converter_path_from_giants_addon', text="", icon="EVENT_G")
-                row.operator("i3dio.download_i3d_converter", text="", icon='WORLD_DATA')
-            case 'AUTOMATIC':
-                #row = c_box.row()
-                #row.operator("i3dio.download_i3d_converter", text="Manage Automatic Download")
-                pass
+            info_box.row().prop(self, "converter_mode_tabs", expand=True)
+            if self.converter_mode_tabs == "AUTOMATIC":
+                if giants_exist:
+                    info_box.label(text="GIANTS I3D Exporter is installed.", icon="TRIA_RIGHT")
+                    info_box.label(text="Click below to set the path automatically:")
+                    row = info_box.row()
+                    row.operator('i3dio.i3d_converter_path_from_giants_addon',
+                                 text="Get Path from GIANTS Addon", icon="FILE_ALIAS")
+                    info_box.separator()
+                info_box.label(text="Automatically download and set up the I3D Converter:", icon="TRIA_RIGHT")
+                row = info_box.row()
+                row.operator("i3dio.download_i3d_converter", text="Download I3D Converter...", icon='INTERNET')
+            else:
+                info_box.label(text="Manually download and set up the I3D Converter:", icon="TRIA_RIGHT")
+                info_box.label(text="1. Download the GIANTS I3D Exporter addon:")
+                row = info_box.row()
+                props = row.operator("wm.url_open", text="gdn.giants-software.com", icon='URL')
+                props.url = "https://gdn.giants-software.com/downloads.php"
+
+                info_box.label(text="2. Extract the .zip file.")
+                info_box.label(text="3. Locate io_export_i3d/util/i3dConverter.exe.")
+                info_box.label(text="4. Move it to a convenient location.")
+                info_box.label(text="5. Use the file browser icon below to set the path manually.")
+        row = box.row(align=True)
+        row.use_property_split = True
+        row.prop(self, 'i3d_converter_path', placeholder="Path to i3dConverter.exe")
 
 
 class I3D_IO_OT_i3d_converter_path_from_giants_addon(bpy.types.Operator):
@@ -60,12 +91,12 @@ class I3D_IO_OT_i3d_converter_path_from_giants_addon(bpy.types.Operator):
     bl_label = "Get I3D converter path from Giants addon"
     bl_description = "Get the i3d converter path from the Giants exporter addon"
     bl_options = {'INTERNAL'}
-    
+
     def execute(self, context):
-        for addon in addon_utils.modules():
-            if addon.bl_info.get("name") == "GIANTS I3D Exporter Tools":
-                bpy.context.preferences.addons['i3dio'].preferences.i3d_converter_path = str(pathlib.PurePath(addon.__file__).parent.joinpath('util/i3dConverter.exe'))
-                break
+        if addon := next((addon for addon in addon_utils.modules()
+                          if addon.bl_info.get("name") == "GIANTS I3D Exporter Tools"), None):
+            path = str(pathlib.PurePath(addon.__file__).parent.joinpath('util/i3dConverter.exe'))
+            context.preferences.addons[base_package].preferences.i3d_converter_path = path
         return {"FINISHED"}
 
 
@@ -129,7 +160,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
             with zipfile.open('io_export_i3d/util/i3dConverter.exe') as zipped_binary, open(binary_path, 'wb') as saved_binary:
                 copyfileobj(zipped_binary, saved_binary)
             # Set I3D Converter Binary path to newly downloaded converter
-            context.preferences.addons['i3dio'].preferences.i3d_converter_path = str(binary_path)
+            context.preferences.addons[base_package].preferences.i3d_converter_path = str(binary_path)
         except (BadZipfile, KeyError, OSError) as e:
             self.report({'WARNING'}, f"The Community I3D Exporter did not succesfully fetch and install the Giants I3D Converter binary! ({e})")
             return {'CANCELLED'}


### PR DESCRIPTION
Blender does not automatically mark add-on preferences as "dirty" when modified via operators,
causing changes to be lost on restart. This fix forces Blender to recognize preference changes,
ensuring that the I3D Converter path is properly saved.

UI improvements:
- Refactored I3D Converter setup into "Automatic" and "Manual" modes using tabs.
- Improved descriptions and labels for better clarity.
- Added a placeholder text for the path field.
- Ensured the I3D Converter path field remains fully visible using `use_property_split = True`.
- Updated operator icons for better visual feedback.

This update makes the preferences UI more intuitive while ensuring the I3D Converter path persists across sessions.