### PR TITLE
fix(xml): remove unnecessary CommentedTreeBuilder

### DIFF
--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -19,20 +19,10 @@ skinned_mesh_prefix = 'SkinnedMesh_'
 i3d_max = 3.40282e+38
 
 
-class CommentedTreeBuilder(ET.TreeBuilder):
-    """
-    This class is used to enable elemtree to NOT delete comments of parsed trees...
-    """
-    def comment(self, data):
-        self.start(ET.Comment, {})
-        self.data(data)
-        self.end(ET.Comment)
-
-
 def parse(*argv, **kwargs) -> ET.ElementTree:
     tree = None
     try:
-        tree = ET.parse(*argv, **kwargs, parser=ET.XMLParser(target=CommentedTreeBuilder()))
+        tree = ET.parse(*argv, **kwargs, parser=ET.XMLParser())
     except (ET.ParseError, FileNotFoundError) as e:
         print(f"Error while parsing xml file: {e}")
     return tree


### PR DESCRIPTION
After testing #259 (PR), some shader files failed to parse correctly due to an XML comment at the top level of the file. Removing CommentedTreeBuilder solves this issue. Since we no longer use it to modify XML files, it can be safely removed.