### PR TITLE
fix(merge-children): Use mesh object as root instead of empty for better UX and export flow

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -268,7 +268,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                 node = i3d.add_merge_group_node(obj, _parent, blender_merge_group.root is obj)
 
             # Default to a regular Shape if none of the special types applied
-            if node is None:
+            else:
                 node = i3d.add_shape_node(obj, _parent)
         case 'ARMATURE':
             node = i3d.add_armature_from_scene(obj, _parent)

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -239,7 +239,6 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
                     )
 
             # Process Skinned Meshes if enabled and MergeChildren wasn't applied
-            # flake8: noqa: W503
             elif ('SKINNED_MESHES' in i3d.settings['features_to_export']
                   and 'ARMATURE' in i3d.settings['object_types_to_export']
                   and (armature_mod := next((mod for mod in obj.modifiers if mod.type == 'ARMATURE'), None))

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -103,58 +103,9 @@ class I3D:
 
         return node_to_return
 
-    def add_merge_children_node(self, empty_object: bpy.types.Object,
-                                parent: Optional[SceneGraphNode] = None) -> SceneGraphNode:
-        self.logger.debug(f"Adding MergeChildrenRoot: {empty_object.name}")
-
-        materials_from_children = set()
-
-        def collect_materials_recursive(obj):
-            for child in obj.children:
-                if child.type == 'MESH':
-                    materials_from_children.update(child.data.materials)
-                collect_materials_recursive(child)
-
-        collect_materials_recursive(empty_object)
-
-        if not materials_from_children:
-            self.logger.warning(f"No materials found in children of {empty_object.name}. "
-                                f"MergeChildrenRoot will not be created.")
-            return None
-
-        # Create a merged mesh object to act as a container for the children
-        # This is necessary to utilize the ShapeNode class and include materials
-        dummy_mesh_data = bpy.data.meshes.new(f"MergeChildren_{empty_object.name}")
-        for material in materials_from_children:
-            dummy_mesh_data.materials.append(material)
-        dummy_mesh_object = bpy.data.objects.new(f"{empty_object.name}_dummy", dummy_mesh_data)
-
-        # Match the transformation of the original empty object
-        dummy_mesh_object.matrix_world = empty_object.matrix_world
-        if empty_object.parent is not None:
-            dummy_mesh_object.parent = empty_object.parent
-            dummy_mesh_object.matrix_parent_inverse = empty_object.matrix_world.inverted()
-
-        first_mesh_child = next(child for child in empty_object.children if child.type == 'MESH')
-
-        def copy_custom_properties(source, target):
-            for key in source.keys():
-                self.logger.debug(f"Copying custom property: {key}")
-                target[key] = source[key]
-
-        copy_custom_properties(first_mesh_child, dummy_mesh_object)
-        copy_custom_properties(first_mesh_child.data.i3d_attributes, dummy_mesh_data.i3d_attributes)
-
-        # Initialize the root node with the dummy mesh object
-        merge_children_root = self._add_node(MergeChildrenRoot, dummy_mesh_object, parent)
-        # Add the children meshes to the root node
-        merge_children_root.add_children_meshes(empty_object)
-
-        # Cleanup the temporary dummy object after processing
-        bpy.data.objects.remove(dummy_mesh_object, do_unlink=True)
-        bpy.data.meshes.remove(dummy_mesh_data, do_unlink=True)
-        self.logger.info(f"Finished merging children into root: {empty_object.name}")
-        return merge_children_root
+    def add_merge_children_node(self, merge_children_object: bpy.types.Object,
+                                parent: SceneGraphNode | None = None) -> SceneGraphNode:
+        return self._add_node(MergeChildrenRoot, merge_children_object, parent)
 
     def add_bone(self, bone_object: bpy.types.Bone, parent: SceneGraphNode | None,
                  root_node: SkinnedMeshRootNode) -> SceneGraphNode:

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -1,5 +1,5 @@
-from typing import Optional
 import bpy
+import mathutils
 
 from .node import SceneGraphNode
 from .shape import (ShapeNode, EvaluatedMesh)
@@ -14,66 +14,59 @@ MERGE_CHILDREN_MAX_INDEX = 32767
 
 
 class MergeChildrenRoot(ShapeNode):
-    def __init__(self, id_: int, merge_children_object: bpy.types.Object, i3d: I3D,
-                 parent: Optional[SceneGraphNode] = None):
-        name = merge_children_object.name
-        if merge_children_object.name.endswith('_dummy'):
-            name = merge_children_object.name.replace('_dummy', '')
-        super().__init__(id_=id_, shape_object=merge_children_object, i3d=i3d, parent=parent, custom_name=name)
+    def __init__(self, id_: int, merge_child_root: bpy.types.Object, i3d: I3D, parent: SceneGraphNode | None = None):
+        super().__init__(id_=id_, shape_object=merge_child_root, i3d=i3d, parent=parent)
 
-    def add_shape(self):
-        """Override to add the merged mesh as the shape."""
+        self._add_children_meshes()
+
+    def add_shape(self) -> None:
+        """Override to prevent adding any data from the root object to the shape."""
         self.shape_id = self.i3d.add_shape(EvaluatedMesh(self.i3d, self.blender_object, node=self), is_generic=True)
         self.xml_elements['IndexedTriangleSet'] = self.i3d.shapes[self.shape_id].element
 
-    def add_children_meshes(self, empty_object: bpy.types.Object):
+    def _process_child_subtree(self, obj: bpy.types.Object, g_value: float, reference_frame: mathutils.Matrix) -> None:
         """
-        Merges all child meshes of `empty_object`. Each *top-level child* (and its descendants)
-        is assigned the same normalized `generic_value`.
+        Recursively processes `obj` and its descendants, assigning `g_value` to each mesh.
 
-        If `apply_transforms` is true, local transforms are baked into the root’s transform.
+        - Mesh objects are added to the evaluated shape with `g_value`.
+        - Non-mesh objects act as interpolation steps but are otherwise ignored.
+        """
+        if obj.type == 'MESH':
+            self.logger.debug(f"Processing mesh: '{obj.name}', g_value: {g_value}")
+            self.i3d.shapes[self.shape_id].append_from_evaluated_mesh(
+                EvaluatedMesh(self.i3d, obj, reference_frame=reference_frame),
+                g_value
+            )
+
+        for child in obj.children:
+            self._process_child_subtree(child, g_value, reference_frame)
+
+    def _add_children_meshes(self) -> None:
+        """
+        Merges all child meshes of `merge_child_root`. Each *top-level child* (and its descendants)
+        is assigned the same normalized `generic_value`, which is used in shaders.
+
+        If `apply_transforms` is True, local transforms are baked into the root’s transform.
         Otherwise, each mesh preserves its own local transform.
-
-        :param empty_object: The root object containing child meshes.
         """
-        apply_child_transforms = empty_object.i3d_merge_children.apply_transforms
-        root_world_matrix = empty_object.matrix_world
-        interpolation_steps = empty_object.i3d_merge_children.interpolation_steps
+        root_obj = self.blender_object
+        apply_child_transforms = root_obj.i3d_merge_children.apply_transforms
+        root_world_matrix = root_obj.matrix_world
+        interpolation_steps = root_obj.i3d_merge_children.interpolation_steps
 
-        self.logger.debug(
-            f"Starting collection of child meshes for '{empty_object.name}'. "
-            f"Interpolation steps: {interpolation_steps}."
-        )
-
-        def process_child_subtree(obj: bpy.types.Object, g_value: float):
-            """
-            Recursively process `obj` and its descendants, assigning `g_value` to every mesh in this branch.
-            """
-            # Use root_matrix to bake transforms into the mesh, or preserve the child's local transform.
-            reference_frame = root_world_matrix if apply_child_transforms else obj.matrix_world
-
-            if obj.type == 'MESH':
-                self.logger.debug(f"Processing mesh: '{obj.name}', g_value: {g_value}")
-                self.i3d.shapes[self.shape_id].append_from_evaluated_mesh(
-                    EvaluatedMesh(self.i3d, obj, reference_frame=reference_frame),
-                    g_value
-                )
-
-            for child in obj.children:
-                process_child_subtree(child, g_value)
+        self.logger.debug(f"Merging child meshes (Interpolation steps: {interpolation_steps})")
 
         g_value_index = 0
-        for child in empty_object.children:
-            # Any object can be processed here.
-            # Non-mesh objects act as "g_value" increments, similar to interpolation steps.
-
+        for child in root_obj.children:
+            # Both mesh and non-mesh objects are processed; non-mesh objects only affect interpolation steps.
             # Generic value for this child and its descendants.
             generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX
+            reference_frame = root_world_matrix if apply_child_transforms else child.matrix_world
             # Process the child and its descendants.
-            process_child_subtree(child, generic_value)
-            # Increment the g_value index for the next child
+            self._process_child_subtree(child, generic_value, reference_frame)
+            # Increment the g_value index for the next group of child meshes.
             g_value_index += interpolation_steps
 
-    def populate_xml_element(self):
-        self.logger.debug("Populating XML element for MergeChildrenRoot")
+    def populate_xml_element(self) -> None:
+        self.logger.debug("Populating XML")
         super().populate_xml_element()

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -91,14 +91,12 @@ class SceneGraphNode(Node):
                  blender_object: [bpy.types.Object, bpy.types.Collection, None],
                  i3d: I3D,
                  parent: Union[SceneGraphNode, None] = None,
-                 custom_name: str = None,
                  ):
         self.children = []
         self.blender_object = blender_object
         self.xml_elements: Dict[str, Union[xml_i3d.XML_Element, None]] = {'Node': None}
 
-        self._name = custom_name or self.blender_object.name
-
+        self._name = self.blender_object.name
         prefix = i3d.settings.get('object_sorting_prefix', "")
         if prefix and (prefix_index := self._name.find(prefix)) > -1 and prefix_index < len(self._name) - 1:
             self._name = self._name[prefix_index + 1:]

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -461,29 +461,29 @@ class I3DMergeChildren(bpy.types.PropertyGroup):
     enabled: BoolProperty(
         name="Enable Merge Children",
         description=(
-            "Enable this object to act as the merge root for exporting its child objects. "
-            "During export, all child objects will be combined into a single merged object."
+            "Marks this object as the Merge Children Root, defining the group of child objects to be merged. "
+            "Only the child meshes will be included in the final merged Shape. "
+            "The root object's mesh data (vertices, triangles, materials, etc.) will NOT be exported, "
+            "but its shape attributes (e.g., cast shadows) and object attributes will still be used."
         ),
         default=False
     )
     apply_transforms: bpy.props.BoolProperty(
         name="Apply Transforms",
         description=(
-            "Bake location, rotation, and scale into each child mesh. When enabled, child meshes retain their "
-            "current position and orientation relative to the root (merge root object). "
-            "When disabled, child meshes will be transformed to align directly with the root object, "
-            "removing their individual offsets and placing them at the root's location."
+            "Controls whether child meshes apply their transforms before merging. "
+            "When enabled, each child mesh keeps its relative position, rotation, and scale. "
+            "When disabled, all child meshes are transformed to match the root object's location and orientation, "
+            "removing their individual offsets."
         ),
         default=False
     )
     interpolation_steps: bpy.props.IntProperty(
         name="Interpolation Steps",
         description=(
-            "Number of additional interpolation steps inserted between merged child objects. "
-            "This is useful for creating smoother animations or transitions in shaders "
-            "that utilize array textures (e.g., for motion paths). "
-            "Make sure the corresponding texture accounts for the same number of steps to "
-            "avoid unexpected offsets in the animation or effect."
+            "Sets the number of interpolation steps for smoother transitions in shaders. "
+            "This affects effects like motion paths that use array textures. "
+            "Ensure the corresponding texture supports the same step count to prevent animation misalignment."
         ),
         default=1,
         min=1,
@@ -623,12 +623,12 @@ class I3D_IO_PT_object_attributes(Panel):
 
         if obj.type == 'EMPTY':
             draw_level_of_detail_attributes(layout, obj, i3d_attributes)
-            draw_merge_children_attributes(layout, obj.i3d_merge_children)
             draw_reference_file_attributes(layout, obj.i3d_reference)
             draw_joint_attributes(layout, i3d_attributes)
 
         elif obj.type == 'MESH':
             draw_rigid_body_attributes(layout, i3d_attributes)
+            draw_merge_children_attributes(layout, obj.i3d_merge_children)
             draw_merge_group_attributes(layout, context)
 
         draw_visibility_condition_attributes(layout, i3d_attributes)
@@ -766,6 +766,7 @@ def draw_merge_group_attributes(layout: bpy.types.UILayout, context: bpy.types.C
     header, panel = layout.panel('i3d_merge_group_panel', default_closed=False)
     header.label(text="Merge Group")
     if panel:
+        panel.enabled = not obj.i3d_merge_children.enabled
         row = panel.row(align=True)
         row.operator('i3dio.choose_merge_group', text="", icon='DOWNARROW_HLT')
 


### PR DESCRIPTION
Now it uses the merge children root object for the entire logic, all object & mesh attributes is now taken directly from the root instead of copying them from first mesh child.