### PR TITLE
feat(subset): add material slot name support

### DIFF
--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -12,9 +12,9 @@ from ..i3d import I3D
 
 
 class MaterialStorage:
-    def __init__(self, material_slot_name: str = None):
+    def __init__(self, triangles: list = None, material_slot_name: str = None):
         self.material_slot_name = material_slot_name
-        self.triangle: list = []
+        self.triangles = triangles or []
 
     def __str__(self):
         return f"triangles={len(self.triangles)}-{self.triangles} " \
@@ -382,7 +382,7 @@ class IndexedTriangleSet(Node):
 
     def _get_material_slot_name(self, _material: bpy.types.Material) -> str | None:
         """Returns the material slot name of the given material if set, otherwise None."""
-        if _material.i3d_attributes.use_custom_material_name:
+        if _material.i3d_attributes.use_material_slot_name:
             return _material.i3d_attributes.material_slot_name or _material.name
         return None
 

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -303,6 +303,18 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         default='1x1'
     )
 
+    use_material_slot_name: BoolProperty(
+        name="Enable Material Slot Name",
+        description="If checked, this material will export a material slot name",
+        default=False
+    )
+
+    material_slot_name: StringProperty(
+        name="Material Slot Name",
+        description="If left empty, the material name will be used instead",
+        default=""
+    )
+
 
 @register
 class I3D_IO_PT_material_shader(Panel):
@@ -323,6 +335,11 @@ class I3D_IO_PT_material_shader(Panel):
 
         layout.prop(material.i3d_attributes, 'shading_rate')
         layout.prop(material.i3d_attributes, 'alpha_blending')
+        box = layout.box()
+        box.prop(material.i3d_attributes, 'use_material_slot_name')
+        row = box.row()
+        row.enabled = material.i3d_attributes.use_material_slot_name
+        row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name:", placeholder=material.name)
 
         layout.use_property_split = False
         layout.prop(material.i3d_attributes, 'source')


### PR DESCRIPTION
FS25

This PR introduces material slot name support for subsets, allowing materials to be uniquely identified 
for configurations such as color setups.

Key details:
- `materialSlotName` is stored per material.
- If enabled, all meshes using that material will have their subsets assigned a materialSlotName.
- This approach keeps the implementation simple while maintaining intended functionality.

### Why not store per mesh per material?
The original attempt in draft PR #229 aimed for a per-mesh per-material slot name system, but this introduced 
significant complexity, particularly when handling:
- **Merge Groups & Merge Children**: Since these combine multiple meshes into one `IndexedTriangleSet`, 
  we would need to prevent duplicate materialSlotNames.
- **UI Management**: Dynamically generating unique slot names for every subset added extra overhead.

Additionally, **GIANTS’ official I3D exporters (both Maya and Blender) also store `materialSlotName` per material**.  
While following GIANTS' standards tend to be a bad thing, the additional complexity of handling per-material per-mesh materialSlotNames seems unnecessary for a feature that is unlikely to be used that way.  
This approach simplifies the implementation while ensuring compatibility and practical usability.

![image](https://github.com/user-attachments/assets/c01d715e-6b1e-440c-b118-aaaf2ef34b19)
