### PR TITLE
fix(shape): handle invalid material indices and empty slots with better fallback logic

### DIFF
--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -398,9 +398,8 @@ class IndexedTriangleSet(Node):
         material_to_subset = {} if not append else None  # Only used when creating new subsets
 
         for triangle in mesh.loop_triangles:
-            # Rare case: a triangle's material index may be invalid (out of range).
-            # This can happen after certain operations (e.g., applying a Boolean modifier),
-            # which may leave behind a 'material_index' attribute on the mesh without syncing it to the material list.
+            # A triangle's material index may be invalid (out of range) if the mesh contains
+            # corrupted or mismatched 'material_index' data. If detected, we assign a fallback material.
             if triangle.material_index >= len(mesh.materials) or triangle.material_index < 0:
                 if not has_warned_for_invalid_index:
                     self.logger.warning("triangle(s) found with invalid material index, assigning fallback material")

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -409,8 +409,8 @@ class IndexedTriangleSet(Node):
                 triangle_material = fallback_material or self.i3d.get_default_material().blender_material
             else:
                 triangle_material = mesh.materials[triangle.material_index]
-                # In Blender, it's possible to add material slots without assigning actual materials.
-                # These show up as None in the list and must be replaced before export.
+                # In Blender, it's possible to assign triangles to material slots that have no material. These show up
+                # as `None` in the material list. If used, they are replaced with a fallback material during export.
                 if triangle_material is None:
                     if not has_warned_for_empty_slot:
                         self.logger.warning("triangle(s) found with empty material slot, assigning fallback material")


### PR DESCRIPTION
Meshes can contain triangles with invalid or out of range material indices, stored in the 'material_index' attribute. The reason this happen in first place I am unsure about 😅 Potentially something could have been broken when jumping between blender versions, importing corrupted geometry or what ever.... This PR will at least handle such cases by assigning either the only valid material (if only one exist in the mesh) or falling back to the default material.

Also improves handling of empty material slots (`None`). If a triangle references such a slot, the same fallback logic is applied: use the only valid material if available, otherwise fall back to the default.

![image](https://github.com/user-attachments/assets/d2c4f60c-80c7-4174-b093-d108645b6c69)

![image](https://github.com/user-attachments/assets/c29eac75-ef7d-46d0-97c7-a0fc50aa24b2)
