### PR TITLE
feat(animation): add support for animation export

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -194,6 +194,9 @@ def _export(i3d: I3D, objects: List[BlenderObject], sort_alphabetical: bool = Tr
     if i3d.deferred_constraints:
         _process_deferred_constraints(i3d)
 
+    if i3d.anim_links:
+        i3d.add_animations()
+
 
 def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None) -> None:
     # Collections are checked first since these are always exported in some form

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -53,6 +53,7 @@ class I3D:
         self.depsgraph = depsgraph
 
         self.all_objects_to_export: List[bpy.types.Object] = []
+        self.animations: dict[int, Animation] = {}
 
     # Private Methods ##################################################################################################
     def _next_available_id(self, id_type: str) -> int:
@@ -180,6 +181,17 @@ class I3D:
             attrib = {'name': attribute.name, 'type': attribute.type.replace('data_', '')}
             attribute_element = xml_i3d.SubElement(node_attribute_element, 'Attribute', attrib=attrib)
             xml_i3d.write_attribute(attribute_element, 'value', getattr(attribute, attribute.type))
+
+    def add_animation(self, node: SceneGraphNode) -> None:
+        """Add an animation for the given SceneGraphNode if it has keyframes."""
+        if not (node.blender_object.animation_data and node.blender_object.animation_data.action):
+            return  # No animation, skip
+        action = node.blender_object.animation_data.action
+        self.logger.info(f"Adding animation '{action.name}' for node '{node.name}' (ID {node.id})")
+        # Use the existing nodeId for the animation
+        animation = Animation(node.id, self, node.blender_object)
+        # Store it in the animations dictionary
+        self.animations[node.id] = animation
 
     def add_material(self, blender_material: bpy.types.Material) -> int:
         name = blender_material.name
@@ -334,3 +346,4 @@ from i3dio.node_classes.merge_children import *
 from i3dio.node_classes.skinned_mesh import *
 from i3dio.node_classes.material import *
 from i3dio.node_classes.file import *
+from i3dio.node_classes.animation import *

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -184,12 +184,10 @@ class I3D:
 
     def add_animation(self, node: SceneGraphNode) -> None:
         """Add an animation for the given SceneGraphNode if it has keyframes."""
-        if not (node.blender_object.animation_data and node.blender_object.animation_data.action):
+        if not (animation_data := node.blender_object.animation_data) or not animation_data.action:
             return  # No animation, skip
-        action = node.blender_object.animation_data.action
-        self.logger.info(f"Adding animation '{action.name}' for node '{node.name}' (ID {node.id})")
         # Use the existing nodeId for the animation
-        animation = Animation(node.id, self, node.blender_object)
+        animation = Animation(node.id, self, node.blender_object, node.parent)
         # Store it in the animations dictionary
         self.animations[node.id] = animation
 

--- a/addon/i3dio/i3d.py
+++ b/addon/i3dio/i3d.py
@@ -39,6 +39,7 @@ class I3D:
         self.processed_objects: Dict[bpy.types.Object, SceneGraphNode] = {}
         self.deferred_constraints: list[tuple[SkinnedMeshBoneNode, bpy.types.Object]] = []
         self.conversion_matrix = conversion_matrix
+        self.conversion_matrix_inv = conversion_matrix.inverted_safe()
 
         self.shapes: Dict[Union[str, int], Union[IndexedTriangleSet, NurbsCurve]] = {}
         self.materials: Dict[Union[str, int], Material] = {}

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -9,8 +9,6 @@ from .skinned_mesh import SkinnedMeshBoneNode
 from .. import xml_i3d, debugging
 from ..i3d import I3D
 
-# https://developer.blender.org/docs/release_notes/4.4/python_api/#slotted-actions
-
 
 class BaseAnimationExport:
     def __init__(self, i3d: I3D, fps: float):

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -2,7 +2,6 @@ import logging
 import math
 import bpy
 from bpy_extras import anim_utils
-from dataclasses import dataclass
 
 from .node import SceneGraphNode
 from .skinned_mesh import SkinnedMeshBoneNode
@@ -20,14 +19,66 @@ class BaseAnimationExport:
                                                   {'object_name': type(self).__name__})
 
 
-class BaseAnimationNode(BaseAnimationExport):
-    def __init__(self, i3d: I3D, fps: float, node: SceneGraphNode | SkinnedMeshBoneNode):
+class Keyframe:
+    @staticmethod
+    def generate_keyframe(i3d: I3D,
+                          node: SceneGraphNode | SkinnedMeshBoneNode,
+                          is_bone: bool,
+                          frame: int,
+                          time_ms: float,
+                          export_translation: bool,
+                          export_rotation: bool,
+                          export_scale: bool) -> xml_i3d.Element:
+
+        i3d.depsgraph.scene.frame_set(frame)
+
+        local_matrix = node.blender_object.matrix_local.copy()
+        if is_bone:
+            if pose_bone := node.root_node.blender_object.pose.bones.get(node.blender_object.name):
+                local_matrix = pose_bone.matrix.copy()
+            if isinstance(node.parent, SkinnedMeshBoneNode):
+                # Bone with bone parent — use raw matrix
+                if parent_pose_bone := node.root_node.blender_object.pose.bones.get(node.parent.blender_object.name):
+                    local_matrix = parent_pose_bone.matrix.inverted_safe() @ local_matrix
+                conv_matrix = local_matrix
+            else:
+                conv_matrix = i3d.conversion_matrix @ local_matrix
+        else:
+            conv_matrix = i3d.conversion_matrix @ local_matrix @ i3d.conversion_matrix.inverted_safe()
+
+        translation, rotation, scale = conv_matrix.decompose()
+        rotation = rotation.to_euler('XYZ')
+        keyframe_element = xml_i3d.Element("Keyframe", {"time": f"{time_ms:.6g}"})
+        if export_translation:
+            keyframe_element.set("translation", "{0:.6g} {1:.6g} {2:.6g}".format(*translation))
+        if export_rotation:
+            keyframe_element.set("rotation", " ".join(f"{math.degrees(a):.6g}" for a in rotation))
+        if export_scale:
+            keyframe_element.set("scale", "{0:.6g} {1:.6g} {2:.6g}".format(*scale))
+
+        return keyframe_element
+
+
+class Keyframes(BaseAnimationExport):
+    def __init__(self,
+                 i3d: I3D,
+                 fps: float,
+                 node: SceneGraphNode | SkinnedMeshBoneNode,
+                 channelbag: bpy.types.ActionChannelbag,
+                 start_frame: int,
+                 end_frame: int):
         super().__init__(i3d, fps)
         self.node = node
         self.is_bone = isinstance(node, SkinnedMeshBoneNode)
-        self.parent_is_bone = isinstance(node.parent, SkinnedMeshBoneNode)
-        self.fcurves: list[bpy.types.FCurve] = []
-        self.should_bake: bool = False
+        self.channelbag = channelbag
+        self.start_frame = start_frame
+        self.end_frame = end_frame
+        self.fcurves = self._filter_fcurves(channelbag)
+        self.has_translation = any(fc.data_path.endswith("location") for fc in self.fcurves)
+        self.has_rotation = any(fc.data_path.endswith("rotation_euler") for fc in self.fcurves)
+        self.has_scale = any(fc.data_path.endswith("scale") for fc in self.fcurves)
+
+        self.xml_element = self._generate_keyframes()
 
     def _filter_fcurves(self, channelbag: bpy.types.ActionChannelbag) -> list[bpy.types.FCurve]:
         if self.is_bone:
@@ -35,87 +86,11 @@ class BaseAnimationNode(BaseAnimationExport):
             return [fc for fc in channelbag.fcurves if f'pose.bones["{bone_name}"]' in fc.data_path]
         return channelbag.fcurves
 
-
-@dataclass
-class KeyframeContext:
-    node: SceneGraphNode | SkinnedMeshBoneNode
-    is_bone: bool
-    frame: float
-    time_ms: float
-    export_translation: bool
-    export_rotation: bool
-    export_scale: bool
-    should_bake: bool = False
-
-
-class Keyframe(BaseAnimationExport):
-    def __init__(self, i3d: I3D, context: KeyframeContext):
-        super().__init__(i3d, i3d.depsgraph.scene.render.fps)
-        self.ctx = context
-        self._generate_keyframe()
-
-    def _generate_keyframe(self):
-        """Generates and returns the XML representation of the keyframe at a specific frame."""
-        """ if self.should_bake:
-            # If baking is needed, we need to sample the keyframe at the current frame
-            self.time_ms = ((self.frame - self.i3d.start_frame) / self.i3d.fps) * 1000 """
-
-        self.i3d.depsgraph.scene.frame_set(int(self.ctx.frame))
-
-        node = self.ctx.node
-
-        if self.ctx.is_bone:
-            if pose_bone := node.root_node.blender_object.pose.bones.get(node.blender_object.name):
-                local_matrix = pose_bone.matrix.copy()
-        else:
-            local_matrix = node.blender_object.matrix_local.copy()
-
-        if self.ctx.is_bone:
-            if isinstance(node.parent, SkinnedMeshBoneNode):
-                # Bone with bone parent — use raw matrix
-                if parent_pose_bone := node.root_node.blender_object.pose.bones.get(node.parent.blender_object.name):
-                    local_matrix = parent_pose_bone.matrix.inverted_safe() @ local_matrix
-                conv_matrix = local_matrix
-            else:
-                conv_matrix = self.i3d.conversion_matrix @ local_matrix
-        else:
-            conv_matrix = self.i3d.conversion_matrix @ local_matrix @ self.i3d.conversion_matrix.inverted_safe()
-
-        final_translation, final_rotation, final_scale = conv_matrix.decompose()
-        final_rotation = final_rotation.to_euler('XYZ')
-        self.xml_element = xml_i3d.Element("Keyframe", {"time": f"{self.ctx.time_ms:.6g}"})
-        if self.ctx.export_translation:
-            self.xml_element.set("translation", "{0:.6g} {1:.6g} {2:.6g}".format(*final_translation))
-        if self.ctx.export_rotation:
-            self.xml_element.set("rotation", " ".join(f"{math.degrees(a):.6g}" for a in final_rotation))
-        if self.ctx.export_scale:
-            self.xml_element.set("scale", "{0:.6g} {1:.6g} {2:.6g}".format(*final_scale))
-
-
-class Keyframes(BaseAnimationNode):
-    def __init__(self,
-                 i3d: I3D,
-                 fps: float,
-                 node: SceneGraphNode | SkinnedMeshBoneNode,
-                 channelbag: bpy.types.ActionChannelbag,
-                 start_frame: int):
-        super().__init__(i3d, fps, node)
-        self.channelbag = channelbag
-        self.start_frame = start_frame
-        self.fcurves = self._filter_fcurves(channelbag)
-        self.has_translation = any(fc.data_path.endswith("location") for fc in self.fcurves)
-        self.has_rotation = any(fc.data_path.endswith("rotation_euler") for fc in self.fcurves)
-        self.has_scale = any(fc.data_path.endswith("scale") for fc in self.fcurves)
-        self.should_bake = self.needs_baking(self.fcurves)
-
-        self.xml_element = self._generate_keyframes()
-
     @staticmethod
-    def needs_baking(fcurves: list[bpy.types.FCurve]) -> bool:
-        """Check if any fcurve requires baking. E.g. if it has animated constraints etc."""
-        return any(not fc.data_path.endswith((
-            "location", "rotation_euler", "rotation_quaternion", "scale")) for fc in fcurves
-        )
+    def _needs_baking(fcurves: list[bpy.types.FCurve]) -> bool:
+        """Returns True if *any* FCurve animates a non-transform property."""
+        valid_paths = ("location", "rotation_euler", "rotation_quaternion", "scale")
+        return any(not fc.data_path.endswith(path) for fc in fcurves for path in valid_paths if fc.data_path)
 
     @property
     def is_empty(self) -> bool:
@@ -123,26 +98,36 @@ class Keyframes(BaseAnimationNode):
 
     def _generate_keyframes(self) -> xml_i3d.Element:
         xml_element = xml_i3d.Element("Keyframes", {"nodeId": str(self.node.id)})
-        keyframe_list = sorted({kp.co.x for fc in self.fcurves for kp in fc.keyframe_points})
+
+        if self._needs_baking(self.fcurves):
+            # When baking, we need to use the start and end frame of the action
+            # and we will get object transforms for each frame between them.
+            keyframe_list = list(range(self.start_frame, self.end_frame + 1))
+            self.i3d.logger.debug(f"[{self.node.name}] Baking keyframes from {self.start_frame} to {self.end_frame}")
+            self.has_translation = True
+            self.has_rotation = True
+            self.has_scale = True
+        else:
+            keyframe_list = sorted({kp.co.x for fc in self.fcurves for kp in fc.keyframe_points})
 
         if not keyframe_list:
+            self.i3d.logger.debug(f"[{self.node.name}] No keyframes found")
             return xml_element
 
         for frame in keyframe_list:
             # Convert frame to time in milliseconds and ensure time always starts with 0ms
             time_ms = ((frame - self.start_frame) / self.fps) * 1000
-            context = KeyframeContext(
-                node=self.node,
-                is_bone=self.is_bone,
-                frame=frame,
-                time_ms=time_ms,
+            keyframe_element = Keyframe.generate_keyframe(
+                self.i3d,
+                self.node,
+                self.is_bone,
+                frame,
+                time_ms,
                 export_translation=self.has_translation,
                 export_rotation=self.has_rotation,
-                export_scale=self.has_scale,
-                should_bake=self.should_bake,
+                export_scale=self.has_scale
             )
-            keyframe = Keyframe(self.i3d, context)
-            xml_element.append(keyframe.xml_element)
+            xml_element.append(keyframe_element)
         return xml_element
 
 
@@ -176,15 +161,16 @@ class Clip(BaseAnimationExport):
             if node.blender_object.type == 'ARMATURE':
                 for bone in node.blender_object.data.bones:
                     if (bone_node := self.i3d.processed_objects.get(bone)):
-                        keyframes = Keyframes(self.i3d, self.fps, bone_node, channelbag, start_frame)
+                        keyframes = Keyframes(self.i3d, self.fps, bone_node, channelbag, start_frame, end_frame)
                         if not keyframes.is_empty:
                             self.xml_element.append(keyframes.xml_element)
                 continue  # skip processing the armature object itself
 
             self.i3d.logger.debug(f"[{node.name}] Processing completed")
 
-            keyframes = Keyframes(self.i3d, self.fps, node, channelbag, start_frame)
+            keyframes = Keyframes(self.i3d, self.fps, node, channelbag, start_frame, end_frame)
             if not keyframes.is_empty:
+                self.i3d.logger.debug(f"[{node.name}] Keyframes found")
                 self.xml_element.append(keyframes.xml_element)
 
         self.xml_element.set("duration", f"{duration_ms:.6g}")

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -111,7 +111,7 @@ class Keyframes(BaseAnimationExport):
             self.logger.debug(f"[{self.node.name}] Found {len(keyframe_list)} keyframes")
 
         if not keyframe_list:
-            self.logger.debug(f"[{self.node.name}] No keyframes found")
+            self.logger.warning(f"[{self.node.name}] No keyframes found")
             return xml_element
 
         for frame in keyframe_list:

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -14,19 +14,25 @@ from ..i3d import I3D
 
 class Keyframe:
     def __init__(self,
-                 i3d: I3D, node: SceneGraphNode | SkinnedMeshBoneNode,
+                 i3d: I3D,
+                 node: SceneGraphNode | SkinnedMeshBoneNode,
+                 is_bone: bool,
                  parent_matrix: mathutils.Matrix,
                  parent_is_bone: bool,
-                 fcurves, frame: float, time_ms: float):
+                 fcurves: list[bpy.types.FCurve],
+                 frame: float,
+                 time_ms: float):
         self.i3d = i3d
         self.node = node
+        self.is_bone = is_bone
         self.parent_matrix = parent_matrix
         self.parent_is_bone = parent_is_bone
         self.fcurves = fcurves
         self.frame = frame
         self.time_ms = time_ms
-        self.is_bone = isinstance(node, SkinnedMeshBoneNode)
         paths = [fcurve.data_path for fcurve in self.fcurves]
+
+        # Determine which properties to export based on the fcurve paths
         self.export_translation = any("location" in path for path in paths)
         self.export_rotation = any("rotation_euler" in path or "rotation_quaternion" in path for path in paths)
         self.export_scale = any("scale" in path for path in paths)
@@ -34,7 +40,7 @@ class Keyframe:
         self._generate_keyframe()
 
     def _generate_keyframe(self):
-        # Evaluate fcurves and bake transform
+        """Generates and returns the XML representation of the keyframe at a specific frame."""
         self.xml_element = xml_i3d.Element("Keyframe", {"time": f"{self.time_ms:.6g}"})
         translation = [0, 0, 0]
         rotation = None
@@ -59,15 +65,10 @@ class Keyframe:
             elif "scale" in path:
                 scale[fcurve.array_index] = value
             elif "hide_viewport" in path:
-                # visibility property in UI is inverted
-                visibility = value == 0.0
+                visibility = value == 0.0  # Visibility property is inverted in UI
 
         if rotation:
-            if used_quaternion:
-                # convert quaternion to euler
-                rotation = mathutils.Quaternion(rotation).to_euler('XYZ')
-            else:
-                rotation = rotation[:3]
+            rotation = mathutils.Quaternion(rotation).to_euler('XYZ') if used_quaternion else rotation[:3]
 
         translation_vec = mathutils.Vector(translation)
         rotation_euler = mathutils.Euler(rotation, 'XYZ') if rotation else None
@@ -78,15 +79,16 @@ class Keyframe:
         rotation_matrix = rotation_euler.to_matrix().to_4x4() if rotation_euler else mathutils.Matrix.Identity(4)
 
         transform_matrix = self.parent_matrix @ translation_matrix @ rotation_matrix @ scale_matrix
-        if self.is_bone and self.parent_is_bone:
-            conversion_matrix = transform_matrix
-        elif self.is_bone:
-            bone_matrix = self.i3d.conversion_matrix @ self.node.blender_object.matrix_local
-            conversion_matrix = bone_matrix @ transform_matrix
+        if self.is_bone:
+            if self.parent_is_bone:
+                conv_matrix = transform_matrix
+            else:
+                bone_matrix = self.i3d.conversion_matrix @ self.node.blender_object.matrix_local
+                conv_matrix = bone_matrix @ transform_matrix
         else:
-            conversion_matrix = self.i3d.conversion_matrix @ transform_matrix @ self.i3d.conversion_matrix.inverted()
+            conv_matrix = self.i3d.conversion_matrix @ transform_matrix @ self.i3d.conversion_matrix.inverted_safe()
 
-        final_translation, final_rotation, final_scale = conversion_matrix.decompose()
+        final_translation, final_rotation, final_scale = conv_matrix.decompose()
         final_rotation = final_rotation.to_euler('XYZ')
         if self.export_translation:
             self.xml_element.set("translation", "{0:.6g} {1:.6g} {2:.6g}".format(*final_translation))
@@ -104,55 +106,62 @@ class Keyframes:
                  i3d: I3D,
                  fps: float,
                  node: SceneGraphNode | SkinnedMeshBoneNode,
-                 channelbag: bpy.types.ActionChannelbag):
+                 channelbag: bpy.types.ActionChannelbag,
+                 start_frame: int):
         self.i3d = i3d
         self.fps = fps
         self.node = node
         self.channelbag = channelbag
+        self.start_frame = start_frame
         self.is_bone = isinstance(node, SkinnedMeshBoneNode)
-        self.is_parent_bone = isinstance(node.parent, SkinnedMeshBoneNode)
+        self.parent_is_bone = isinstance(node.parent, SkinnedMeshBoneNode)
+        self.fcurves = self._filter_fcurves()
 
-        self.max_frame = 0
-        self.has_data = False
-        self.xml_element = xml_i3d.Element("Keyframes", {"nodeId": str(node.id)})
-        self.fcurves = self.channelbag.fcurves
+        self.xml_element = self._generate_keyframes()
 
-        self._generate_keyframes()
-
-    def _generate_keyframes(self):
+    def _filter_fcurves(self) -> list[bpy.types.FCurve]:
+        """Filter fcurves based on the node type."""
         if self.is_bone:
             bone_name = self.node.blender_object.name
-            filtered_fcurves = [fc for fc in self.fcurves if f'pose.bones["{bone_name}"]' in fc.data_path]
-            if not filtered_fcurves:
-                return
-            self.fcurves = filtered_fcurves
+            return [fc for fc in self.channelbag.fcurves if f'pose.bones["{bone_name}"]' in fc.data_path]
+        return self.channelbag.fcurves
 
+    def _get_parent_matrix(self) -> mathutils.Matrix:
+        """Get the matrix of the node's parent, accounting for bones and collapsed armatures."""
+        parent = self.node.parent
+        parent_matrix = parent.blender_object.matrix_local.inverted_safe() if parent else mathutils.Matrix.Identity(4)
+        if self.is_bone:
+            if self.parent_is_bone:
+                # For child bones, the transform is relative to the parent's local space
+                return parent_matrix @ self.node.blender_object.matrix_local
+            matrix = parent_matrix
+            if self.node.root_node.is_collapsed:
+                # Include armature's transform if the armature object is collapsed
+                armature_inv_matrix = self.node.root_node.blender_object.matrix_local.inverted()
+                matrix = armature_inv_matrix @ matrix
+            return matrix
+        return parent_matrix  # Non-bone nodes use inverted parent matrix directly
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.xml_element
+
+    def _generate_keyframes(self) -> xml_i3d.Element:
+        xml_element = xml_i3d.Element("Keyframes", {"nodeId": str(self.node.id)})
         keyframe_list = sorted({kp.co.x for fc in self.fcurves for kp in fc.keyframe_points})
 
         if not keyframe_list:
-            return
+            return xml_element
 
-        self.has_data = True
-        self.max_frame = keyframe_list[-1]
-        first_frame = keyframe_list[0]
-
-        parent = self.node.parent
-        if self.is_bone and self.is_parent_bone:
-            # To calculate the correct transform, we must include the bone's edit bone matrix.
-            # This is because the pose bone's transform is relative to the edit bone's transform.
-            parent_matrix = parent.blender_object.matrix_local.inverted() @ self.node.blender_object.matrix_local
-        elif self.is_bone:
-            parent_matrix = parent.blender_object.matrix_local.inverted() if parent else mathutils.Matrix.Identity(4)
-            # Include armatre matrix if bone is root bone and armature is collapsed
-            if self.node.root_node.is_collapsed:
-                parent_matrix = self.node.root_node.blender_object.matrix_local.inverted() @ parent_matrix
-        else:
-            parent_matrix = parent.blender_object.matrix_local.inverted() if parent else mathutils.Matrix.Identity(4)
+        parent_matrix = self._get_parent_matrix()
 
         for frame in keyframe_list:
-            time_ms = ((frame - first_frame) / self.fps) * 1000
-            keyframe = Keyframe(self.i3d, self.node, parent_matrix, self.parent_is_bone, self.fcurves, frame, time_ms)
-            self.xml_element.append(keyframe.xml_element)
+            time_ms = ((frame - self.start_frame) / self.fps) * 1000
+            keyframe = Keyframe(
+                self.i3d, self.node, self.is_bone, parent_matrix, self.parent_is_bone, self.fcurves, frame, time_ms
+            )
+            xml_element.append(keyframe.xml_element)
+        return xml_element
 
 
 class Clip:
@@ -172,8 +181,8 @@ class Clip:
         self._generate_keyframes()
 
     def _generate_keyframes(self):
-        max_frame = 0
-        keyframes_written = 0
+        start_frame, end_frame = map(int, self.action.frame_range)
+        duration_ms = ((end_frame - start_frame) / self.fps) * 1000
 
         for node, slot in self.node_slot_pairs:
             if not (channelbag := anim_utils.action_get_channelbag_for_slot(self.action, slot)):
@@ -184,24 +193,19 @@ class Clip:
             if node.blender_object.type == 'ARMATURE':
                 for bone in node.blender_object.data.bones:
                     if (bone_node := self.i3d.processed_objects.get(bone)):
-                        keyframes = Keyframes(self.i3d, self.fps, bone_node, channelbag)
-                        if keyframes.has_data:
+                        keyframes = Keyframes(self.i3d, self.fps, bone_node, channelbag, start_frame)
+                        if not keyframes.is_empty:
                             self.xml_element.append(keyframes.xml_element)
-                            max_frame = max(max_frame, keyframes.max_frame)
-                            keyframes_written += 1
                 continue  # skip processing the armature object itself
 
             self.i3d.logger.debug(f"[{node.name}] Processing completed")
 
-            keyframes = Keyframes(self.i3d, self.fps, node, channelbag)
-            if keyframes.has_data:
+            keyframes = Keyframes(self.i3d, self.fps, node, channelbag, start_frame)
+            if not keyframes.is_empty:
                 self.xml_element.append(keyframes.xml_element)
-                max_frame = max(max_frame, keyframes.max_frame)
-                keyframes_written += 1
 
-        duration_ms = (max_frame / self.fps) * 1000
         self.xml_element.set("duration", f"{duration_ms:.6g}")
-        self.xml_element.set("count", str(keyframes_written))
+        self.xml_element.set("count", str(len(self.xml_element)))
 
 
 class AnimationSet:

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -69,7 +69,7 @@ class Keyframe(BaseAnimationExport):
 
     @staticmethod
     def needs_baking(fcurves: list[bpy.types.FCurve]) -> bool:
-        """Check if any fcurve requires baking."""
+        """Check if any fcurve requires baking. E.g. if it has animated constraints etc."""
         return any(not fc.data_path.endswith((
             "location", "rotation_euler", "rotation_quaternion", "scale", "hide_viewport")) for fc in fcurves
         )

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -1,16 +1,22 @@
 import logging
 import math
 import bpy
+from bpy_extras import anim_utils
 import mathutils
+
+from .node import SceneGraphNode
 from .. import xml_i3d, debugging
 from ..i3d import I3D
 
+# https://developer.blender.org/docs/release_notes/4.4/python_api/#slotted-actions
+
 
 class Animation:
-    def __init__(self, id_: int, i3d: I3D, animated_object: bpy.types.Object):
+    def __init__(self, id_: int, i3d: I3D, animated_object: bpy.types.Object, parent: SceneGraphNode | None = None):
         self.id = id_
         self.i3d = i3d
         self.animated_object = animated_object
+        self.parent = parent
         self.name = animated_object.name
         self.fps = i3d.depsgraph.scene.render.fps
 
@@ -18,6 +24,14 @@ class Animation:
                                                   {'object_name': self.name})
 
         self.logger.debug("Initialized animation")
+
+        action = self.animated_object.animation_data.action
+        action_slot = self.animated_object.animation_data.action_slot
+        channelbag = anim_utils.action_get_channelbag_for_slot(action, action_slot)
+
+        if not channelbag:
+            self.logger.warning(f"No action found for '{self.animated_object.name}', skipping keyframes.")
+            return
 
         self.animation_root = i3d.xml_elements['Animation']
         self.animation_sets = i3d.xml_elements.get('AnimationSets')
@@ -31,57 +45,59 @@ class Animation:
         if self.animation_set is None:
             self.animation_set = xml_i3d.SubElement(self.animation_sets, 'AnimationSet', {"name": self.name})
 
-        self._extract_animation_clips()
-
-    def _extract_animation_clips(self) -> None:
-        """Extracts animation keyframes and structures them inside a Clip."""
-        anim_data = self.animated_object.animation_data
-        action = anim_data.action
-        if not action:
-            self.logger.warning(f"No action found for '{self.animated_object.name}', skipping keyframes.")
-            return
-
+        fcurves = channelbag.fcurves
         # Compute animation duration (last frame converted to milliseconds)
-        duration = max((kp.co.x for fcurve in action.fcurves for kp in fcurve.keyframe_points), default=0)
-        duration = (duration / self.fps) * 1000  # Convert to milliseconds
+        duration = max((kp.co.x for fcurve in fcurves for kp in fcurve.keyframe_points), default=0)
+        duration = (duration / self.fps) * 1000  # i3d expects time in milliseconds
 
         # Create Clip element inside AnimationSet
-        self.clip = xml_i3d.SubElement(self.animation_set, "Clip", {"name": action.name, "duration": f"{duration:.6f}"})
+        self.clip = xml_i3d.SubElement(self.animation_set, "Clip", {"name": action_slot.name_display,
+                                                                    "duration": f"{duration:.6f}"})
         keyframes_element = xml_i3d.SubElement(self.clip, "Keyframes", {"nodeId": str(self.id)})
 
-        # Extract and store keyframes
-        self._extract_keyframes(action, keyframes_element)
+        self._extract_keyframes(fcurves, keyframes_element)
 
-    def _extract_keyframes(self, action: bpy.types.Action, keyframes_element: xml_i3d.Element) -> None:
-        """Extracts keyframes efficiently, caching transformations and handling hidden object updates."""
+    def _extract_keyframes(self,
+                           fcurves: bpy.types.ActionChannelbagFCurves,
+                           keyframes_element: xml_i3d.Element) -> None:
+        """Extracts keyframes"""
 
-        # Collect keyframes from F-Curves
-        keyframes = set()
-        for fcurve in action.fcurves:
-            for keyframe in fcurve.keyframe_points:
-                keyframes.add(keyframe.co.x)
+        keyframes = {keyframe.co.x for fcurve in fcurves for keyframe in fcurve.keyframe_points}
+        if not keyframes:
+            return
 
         keyframe_data = {}
 
-        export_translation = any("location" in fcurve.data_path for fcurve in action.fcurves)
-        export_rotation = any("rotation_euler" in fcurve.data_path for fcurve in action.fcurves)
-        export_scale = any("scale" in fcurve.data_path for fcurve in action.fcurves)
+        # No need to write keyframes if they are empty
+        export_translation = any("location" in fcurve.data_path for fcurve in fcurves)
+        export_rotation = any("rotation_euler" in fcurve.data_path for fcurve in fcurves)
+        export_scale = any("scale" in fcurve.data_path for fcurve in fcurves)
+        export_visibility = any("hide_viewport" in fcurve.data_path for fcurve in fcurves)
 
-        for time in sorted(list(keyframes)):  # Ensure sorted order
-            frame = int(time)
-            time_ms = (frame / self.fps) * 1000  # Convert to milliseconds
+        parent_matrix = (self.parent.blender_object.matrix_world.inverted()
+                         if self.parent else mathutils.Matrix.Identity(4))
+
+        for frame in sorted(list(keyframes)):
+            time_ms = (frame / self.fps) * 1000  # i3d expects time in milliseconds
 
             translation = [0, 0, 0]
             rotation = [0, 0, 0] if export_rotation else None
             scale = [1, 1, 1]
+            visibility = True
 
-            for fcurve in action.fcurves:
-                if "location" in fcurve.data_path:
-                    translation[fcurve.array_index] = fcurve.evaluate(frame)
-                elif "rotation_euler" in fcurve.data_path:
-                    rotation[fcurve.array_index] = fcurve.evaluate(frame)
-                elif "scale" in fcurve.data_path:
-                    scale[fcurve.array_index] = fcurve.evaluate(frame)
+            for fcurve in fcurves:
+                value = fcurve.evaluate(frame)
+                path = fcurve.data_path
+                if "location" in path:
+                    translation[fcurve.array_index] = value
+                elif "rotation_euler" in path:
+                    rotation[fcurve.array_index] = value
+                elif "scale" in path:
+                    scale[fcurve.array_index] = value
+                elif "hide_viewport" in path:
+                    # `hide_viewport` has invert_checkbox enabled in Blender's UI.
+                    # API/fcurve stores 0.0 when visible and 1.0 when hidden.
+                    visibility = fcurve.evaluate(frame) == 0.0
 
             translation_vec = mathutils.Vector(translation)
             rotation_euler = mathutils.Euler(rotation, 'XYZ') if rotation else None
@@ -96,21 +112,15 @@ class Animation:
             else:
                 rotation_matrix = mathutils.Matrix.Identity(4)
 
-            transform_matrix = translation_matrix @ rotation_matrix @ scale_matrix
-
+            # Relative to parent
+            transform_matrix = parent_matrix @ translation_matrix @ rotation_matrix @ scale_matrix
             conversion_matrix = self.i3d.conversion_matrix @ transform_matrix @ self.i3d.conversion_matrix.inverted()
 
             final_translation, final_rotation, final_scale = conversion_matrix.decompose()
             if export_rotation:
                 final_rotation = final_rotation.to_euler('XYZ')
 
-            visibility = "true"
-            if any(fcurve.data_path.endswith("hide_viewport") for fcurve in action.fcurves):
-                hide_fcurve = next((f for f in action.fcurves if f.data_path.endswith("hide_viewport")), None)
-                if hide_fcurve and hide_fcurve.evaluate(frame) > 0.5:
-                    visibility = "false"
-
-            keyframe_attribs = {"time": str(time_ms), "visibility": visibility}
+            keyframe_attribs = {"time": str(time_ms)}
             if export_translation:
                 keyframe_attribs["translation"] = "{0:.6g} {1:.6g} {2:.6g}".format(*final_translation)
             if export_rotation:
@@ -119,7 +129,9 @@ class Animation:
             if export_scale:
                 keyframe_attribs["scale"] = "{0:.6g} {1:.6g} {2:.6g}".format(*final_scale)
 
+            if export_visibility:
+                keyframe_attribs["visibility"] = str(visibility).lower()
+
             xml_i3d.SubElement(keyframes_element, "Keyframe", keyframe_attribs)
-            self.logger.debug(f"Extracted keyframe at frame {frame} with visibility {visibility}")
 
         self.logger.debug(f"Extracted {len(keyframe_data)} keyframes for '{self.animated_object.name}'")

--- a/addon/i3dio/node_classes/animation.py
+++ b/addon/i3dio/node_classes/animation.py
@@ -1,0 +1,125 @@
+import logging
+import math
+import bpy
+import mathutils
+from .. import xml_i3d, debugging
+from ..i3d import I3D
+
+
+class Animation:
+    def __init__(self, id_: int, i3d: I3D, animated_object: bpy.types.Object):
+        self.id = id_
+        self.i3d = i3d
+        self.animated_object = animated_object
+        self.name = animated_object.name
+        self.fps = i3d.depsgraph.scene.render.fps
+
+        self.logger = debugging.ObjectNameAdapter(logging.getLogger(f"{__name__}.{type(self).__name__}"),
+                                                  {'object_name': self.name})
+
+        self.logger.debug("Initialized animation")
+
+        self.animation_root = i3d.xml_elements['Animation']
+        self.animation_sets = i3d.xml_elements.get('AnimationSets')
+
+        if self.animation_sets is None:
+            self.animation_sets = xml_i3d.SubElement(self.animation_root, "AnimationSets")
+            i3d.xml_elements['AnimationSets'] = self.animation_sets
+
+        self.animation_set = next((anim_set for anim_set in self.animation_sets.findall('AnimationSet')
+                                   if anim_set.get('name') == self.name), None)
+        if self.animation_set is None:
+            self.animation_set = xml_i3d.SubElement(self.animation_sets, 'AnimationSet', {"name": self.name})
+
+        self._extract_animation_clips()
+
+    def _extract_animation_clips(self) -> None:
+        """Extracts animation keyframes and structures them inside a Clip."""
+        anim_data = self.animated_object.animation_data
+        action = anim_data.action
+        if not action:
+            self.logger.warning(f"No action found for '{self.animated_object.name}', skipping keyframes.")
+            return
+
+        # Compute animation duration (last frame converted to milliseconds)
+        duration = max((kp.co.x for fcurve in action.fcurves for kp in fcurve.keyframe_points), default=0)
+        duration = (duration / self.fps) * 1000  # Convert to milliseconds
+
+        # Create Clip element inside AnimationSet
+        self.clip = xml_i3d.SubElement(self.animation_set, "Clip", {"name": action.name, "duration": f"{duration:.6f}"})
+        keyframes_element = xml_i3d.SubElement(self.clip, "Keyframes", {"nodeId": str(self.id)})
+
+        # Extract and store keyframes
+        self._extract_keyframes(action, keyframes_element)
+
+    def _extract_keyframes(self, action: bpy.types.Action, keyframes_element: xml_i3d.Element) -> None:
+        """Extracts keyframes efficiently, caching transformations and handling hidden object updates."""
+
+        # Collect keyframes from F-Curves
+        keyframes = set()
+        for fcurve in action.fcurves:
+            for keyframe in fcurve.keyframe_points:
+                keyframes.add(keyframe.co.x)
+
+        keyframe_data = {}
+
+        export_translation = any("location" in fcurve.data_path for fcurve in action.fcurves)
+        export_rotation = any("rotation_euler" in fcurve.data_path for fcurve in action.fcurves)
+        export_scale = any("scale" in fcurve.data_path for fcurve in action.fcurves)
+
+        for time in sorted(list(keyframes)):  # Ensure sorted order
+            frame = int(time)
+            time_ms = (frame / self.fps) * 1000  # Convert to milliseconds
+
+            translation = [0, 0, 0]
+            rotation = [0, 0, 0] if export_rotation else None
+            scale = [1, 1, 1]
+
+            for fcurve in action.fcurves:
+                if "location" in fcurve.data_path:
+                    translation[fcurve.array_index] = fcurve.evaluate(frame)
+                elif "rotation_euler" in fcurve.data_path:
+                    rotation[fcurve.array_index] = fcurve.evaluate(frame)
+                elif "scale" in fcurve.data_path:
+                    scale[fcurve.array_index] = fcurve.evaluate(frame)
+
+            translation_vec = mathutils.Vector(translation)
+            rotation_euler = mathutils.Euler(rotation, 'XYZ') if rotation else None
+            scale_vec = mathutils.Vector(scale)
+
+            translation_matrix = mathutils.Matrix.Translation(translation_vec)
+            scale_matrix = mathutils.Matrix.Diagonal(scale_vec).to_4x4()
+
+            if export_rotation:
+                rotation_euler = mathutils.Euler(rotation, 'XYZ')
+                rotation_matrix = rotation_euler.to_matrix().to_4x4()
+            else:
+                rotation_matrix = mathutils.Matrix.Identity(4)
+
+            transform_matrix = translation_matrix @ rotation_matrix @ scale_matrix
+
+            conversion_matrix = self.i3d.conversion_matrix @ transform_matrix @ self.i3d.conversion_matrix.inverted()
+
+            final_translation, final_rotation, final_scale = conversion_matrix.decompose()
+            if export_rotation:
+                final_rotation = final_rotation.to_euler('XYZ')
+
+            visibility = "true"
+            if any(fcurve.data_path.endswith("hide_viewport") for fcurve in action.fcurves):
+                hide_fcurve = next((f for f in action.fcurves if f.data_path.endswith("hide_viewport")), None)
+                if hide_fcurve and hide_fcurve.evaluate(frame) > 0.5:
+                    visibility = "false"
+
+            keyframe_attribs = {"time": str(time_ms), "visibility": visibility}
+            if export_translation:
+                keyframe_attribs["translation"] = "{0:.6g} {1:.6g} {2:.6g}".format(*final_translation)
+            if export_rotation:
+                keyframe_attribs["rotation"] = "{0:.6g} {1:.6g} {2:.6g}".format(*[math.degrees(angle)
+                                                                                  for angle in final_rotation])
+            if export_scale:
+                keyframe_attribs["scale"] = "{0:.6g} {1:.6g} {2:.6g}".format(*final_scale)
+
+            xml_i3d.SubElement(keyframes_element, "Keyframe", keyframe_attribs)
+            self.logger.debug(f"Extracted keyframe at frame {frame} with visibility {visibility}")
+
+        self.logger.debug(f"Extracted {len(keyframe_data)} keyframes for '{self.animated_object.name}'")

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -110,6 +110,9 @@ class SceneGraphNode(Node):
         except AttributeError:
             pass
 
+        # Check and process animation
+        self.i3d.add_animation(self)
+
         self.add_i3d_mapping_to_xml()
 
         self.logger.debug(f"Initialized as a '{self.__class__.__name__}'")

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -88,9 +88,9 @@ class SceneGraphNode(Node):
     ID_FIELD_NAME = 'nodeId'
 
     def __init__(self, id_: int,
-                 blender_object: [bpy.types.Object, bpy.types.Collection, None],
+                 blender_object: bpy.types.Object | bpy.types.Collection | None,
                  i3d: I3D,
-                 parent: Union[SceneGraphNode, None] = None,
+                 parent: SceneGraphNode | None = None,
                  ):
         self.children = []
         self.blender_object = blender_object

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -110,8 +110,8 @@ class SceneGraphNode(Node):
         except AttributeError:
             pass
 
-        # Check and process animation
-        self.i3d.add_animation(self)
+        if "ANIMATIONS" in i3d.settings['features_to_export'] and isinstance(self.blender_object, bpy.types.Object):
+            self.i3d.collect_animation_link(self)
 
         self.add_i3d_mapping_to_xml()
 

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -269,7 +269,12 @@ class I3D_IO_OT_export(Operator, ExportHelper):
         else:
             settings = self.as_keywords(ignore=("filepath", "filter_glob"))
 
+        original_frame = context.scene.frame_current
+        context.scene.frame_set(0)
+
         status = exporter.export_blend_to_i3d(self, self.filepath, self.axis_forward, self.axis_up, settings)
+
+        context.scene.frame_set(original_frame)
 
         if status['success']:
             self.report({'INFO'}, f"I3D Export Successful! It took {status['time']:.3f} seconds")

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -137,10 +137,11 @@ class I3D_IO_OT_export(Operator, ExportHelper):
                                                  "the armature and bone structure will still be exported, "
                                                  "but the meshes wont be bound to it"),
             ('MERGE_CHILDREN', "Merge Children", "Merge the child objects of empties with Merge Children enabled "
-                                                 "into a single exported mesh")
+                                                 "into a single exported mesh"),
+            ('ANIMATIONS', "Animations", "Export animations"),
         ),
         options={'ENUM_FLAG'},
-        default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN'},
+        default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN', 'ANIMATIONS'},
     )
 
     copy_files: BoolProperty(

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -141,7 +141,7 @@ class I3D_IO_OT_export(Operator, ExportHelper):
             ('ANIMATIONS', "Animations", "Export animations"),
         ),
         options={'ENUM_FLAG'},
-        default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN', 'ANIMATIONS'},
+        default={'MERGE_GROUPS', 'SKINNED_MESHES', 'MERGE_CHILDREN'},
     )
 
     copy_files: BoolProperty(


### PR DESCRIPTION
This PR introduces animation export support. Blender 4.4 is required.

- Supports armatures and their bones
- Supports regular objects
- Supports slotted actions (Blender 4.4+, [see release notes](https://developer.blender.org/docs/release_notes/4.4/python_api/#slotted-actions))
- Supports standard F-Curve keyframes (translation, rotation (Euler/Quaternion), and scale)
- Supports constraint-driven animations (e.g. animated offset factor in Follow Path)