### PR TITLE
fix(mesh): remove "use vertex colors" property

### DIFF
--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -238,7 +238,7 @@ class IndexedTriangleSet(Node):
 
                 # Add vertex color
                 vertex_color = None
-                if mesh.i3d_attributes.use_vertex_colors and len(mesh.color_attributes):
+                if len(mesh.color_attributes):
                     # Use the active color layer or fallback to the first (GE supports only one layer)
                     color_layer = mesh.color_attributes.active_color or mesh.color_attributes[0]
 

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -116,12 +116,6 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         poll=lambda self, obj: obj.type == 'MESH' and obj is not bpy.context.object
     )
 
-    use_vertex_colors: BoolProperty(
-        name="Use Vertex Colors",
-        description="Enable to export vertex colors for this object",
-        default=False
-    )
-
 
 @register
 class I3D_IO_PT_Mesh_Presets(presets.PresetPanel, Panel):
@@ -181,7 +175,6 @@ class I3D_IO_PT_shape_attributes(Panel):
         op.used_bits = 8
         layout.prop(mesh.i3d_attributes, "decal_layer")
         layout.prop(mesh.i3d_attributes, 'fill_volume')
-        layout.prop(mesh.i3d_attributes, 'use_vertex_colors')
 
         header, panel = layout.panel('i3d_bounding_volume', default_closed=False)
         header.label(text="I3D Bounding Volume")


### PR DESCRIPTION
Removed the "use vertex colors" property after discussions across multiple channels. We concluded that the property is likely to cause more confusion than benefit. It's difficult to expose this setting in a clearly visible way, which could lead to misunderstandings—especially for new users who expect vertex colors to be exported by default.

We may revisit this in the future with a better approach.