### PR TITLE
fix(exporter): skip invalid export settings

### DIFF
--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -251,11 +251,14 @@ class I3D_IO_OT_export(Operator, ExportHelper):
         if settings:
             for key, value in settings.items():
                 if hasattr(self, key):
-                    current_value = getattr(self, key)
-                    if isinstance(current_value, set) and isinstance(value, list):
-                        setattr(self, key, set(value))
-                    else:
-                        setattr(self, key, value)
+                    try:
+                        current_value = getattr(self, key)
+                        if isinstance(current_value, set) and isinstance(value, list):
+                            setattr(self, key, set(value))
+                        else:
+                            setattr(self, key, value)
+                    except Exception:
+                        pass
         return ExportHelper.invoke(self, context, event)
 
     def execute(self, context):


### PR DESCRIPTION
If a user opens a .blend file that was saved with a newer version of the exporter (with additional export settings), some of those settings might not exist in the older version they have installed.
This situation is rare, but it can happen when sharing files or switching back to a previous release.