### PR TITLE
fix(shape): ensure final materialIds are written to merge group/children

### DIFF
--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -18,6 +18,7 @@ class MergeChildrenRoot(ShapeNode):
         super().__init__(id_=id_, shape_object=merge_child_root, i3d=i3d, parent=parent)
 
         self._add_children_meshes()
+        self._write_attribute('materialIds', self.i3d.shapes[self.shape_id].material_ids)
 
     def add_shape(self) -> None:
         """Override to prevent adding any data from the root object to the shape."""

--- a/addon/i3dio/node_classes/merge_group.py
+++ b/addon/i3dio/node_classes/merge_group.py
@@ -37,6 +37,7 @@ class MergeGroupRoot(ShapeNode):
         self._write_attribute('skinBindNodeIds', self.skin_bind_ids[:-1])
         self.i3d.shapes[self.shape_id].append_from_evaluated_mesh(
             EvaluatedMesh(self.i3d, child.blender_object, reference_frame=self.blender_object.matrix_world))
+        self._write_attribute('materialIds', self.i3d.shapes[self.shape_id].material_ids)
 
     def populate_xml_element(self):
         super().populate_xml_element()

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -452,7 +452,14 @@ class IndexedTriangleSet(Node):
         self.logger.debug(f"Material slot order being processed: {', '.join(m.name for m in ordered_used_materials)}")
 
         # Build the final export data using the ordered list
-        self.material_ids = [self.i3d.add_material(m) for m in ordered_used_materials]
+        # Combine existing material_ids with new ones, preserving order and uniqueness
+        new_material_ids = [self.i3d.add_material(m) for m in ordered_used_materials]
+        # Preserve order: existing first, then new ones not already present
+        combined_ids = list(self.material_ids) if append or self.is_merge_group else []
+        for matid in new_material_ids:
+            if matid not in combined_ids:
+                combined_ids.append(matid)
+        self.material_ids = combined_ids
         self.tangent = self.tangent or any(self.i3d.materials[m_id].is_normalmapped() for m_id in self.material_ids)
 
         # If appending, we add to the existing self.materials dictionary. Otherwise, we create new subsets.


### PR DESCRIPTION
Not very pretty, but a quick working fix for merge group/children missing full materialIds