### PR TITLE
feat(reference): add runtime_loaded and child_path properties

### DIFF
--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -265,6 +265,11 @@ class TransformGroupNode(SceneGraphNode):
             return
         self.logger.debug(f"Reference path: {reference_path!r}")
         self._write_attribute('referenceId', self.i3d.add_file_reference(reference_path))
+        if not (runtime_loaded := self.blender_object.i3d_reference.runtime_loaded):
+            # Default is True so only write if False
+            self._write_attribute('referenceRuntimeLoaded', runtime_loaded)
+        if (child_path := self.blender_object.i3d_reference.child_path):
+            self._write_attribute('referenceChildPath', child_path)
 
     def populate_xml_element(self):
         super().populate_xml_element()

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -530,6 +530,24 @@ class I3DReferenceData(bpy.types.PropertyGroup):
         default='',
         subtype='FILE_PATH'
     )
+    runtime_loaded: BoolProperty(
+        name="Runtime Loaded",
+        description=(
+            "If enabled, the referenced I3D file will be loaded in-game at runtime. "
+            "Disable for objects managed by XML (e.g. lights) or if you only want to preview in Giants Editor. "
+            "Most references should NOT be runtime loaded."
+        ),
+        default=False  # Default in GE is True, but for most use cases False makes more sense
+    )
+    child_path: StringProperty(
+        name="Child Path",
+        description=(
+            "Selects which root node or sub-node to load from the referenced I3D. "
+            "e.g. '0>' for the first root node, '1>' for the second. If left empty and the file has multiple "
+            "root nodes, you'll get a warning, but the first node ('0>') will be used by default in Giants Editor."
+        ),
+        default=''
+    )
 
 
 @register
@@ -837,6 +855,8 @@ def draw_reference_file_attributes(layout: bpy.types.UILayout, i3d_reference: bp
     header.label(text="Reference File")
     if panel:
         panel.prop(i3d_reference, 'path')
+        panel.prop(i3d_reference, 'runtime_loaded')
+        panel.prop(i3d_reference, 'child_path', placeholder="0>")
 
 
 def draw_merge_group_attributes(layout: bpy.types.UILayout, context: bpy.types.Context) -> None:


### PR DESCRIPTION
New I3D reference props for FS25: referenceRuntimeLoaded and referenceChildPath