### PR TITLE
refactor(file): enhance filepath resolution logic for export compatibility

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -209,7 +209,6 @@ class Material(Node):
                         parameter_dict['value'] = f'{value[0]:.6f}'
                         xml_i3d.SubElement(self.element, 'CustomParameter', parameter_dict)
                 else:
-                    print(f"Processing parameter '{pname}' with value: {value}, default: {default}")
                     if not utility.vector_compare(mathutils.Vector(value), mathutils.Vector(default)):
                         parameter_dict['value'] = ' '.join(f'{v:.6f}' for v in value)
                         xml_i3d.SubElement(self.element, 'CustomParameter', parameter_dict)


### PR DESCRIPTION
- When "Copy Files" is disabled, the exporter now writes file paths relative to the .blend file instead of absolute paths (still used as a "last option")
- This matches typical modding workflows where raw textures (like .png) are used during development in Blender, and the converted .dds files are placed in the target export folder with a "mirrored" structure.
- This approach gives users more flexibility to organize their project folders however they want.
- In the future, we can extend the exporter to support automatic texture conversion using the GIANTS Texture Converter.

Note: GIANTS Editor will always use the matching .dds file in the referenced location, even if the .i3d path points to a .png.