### PR TITLE
refactor(mesh): remove 'fill_volume' property

### DIFF
--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Decals-Big.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Decals-Big.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 1
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Decals-Small.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Decals-Small.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Exterior.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Exterior.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-IndoorHud.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-IndoorHud.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Interior.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Interior.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Lights-Coronas.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Lights-Coronas.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Lights-Static.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Lights-Static.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-Mirrors.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-Mirrors.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 1
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-WindowsInside.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-WindowsInside.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/NonPhysics-WindowsOutside.py
+++ b/addon/i3dio/presets/i3dio/mesh/NonPhysics-WindowsOutside.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Default.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Default.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-EmitterShape.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-EmitterShape.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-ExactFillRootNode.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-ExactFillRootNode.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-FillVolume.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-FillVolume.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = True

--- a/addon/i3dio/presets/i3dio/mesh/Physics-ShadowFocusBox.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-ShadowFocusBox.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-StaticObject.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-StaticObject.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-TrafficVehicle.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-TrafficVehicle.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-AICollisionTrigger.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-AICollisionTrigger.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-DiscargeTrailerTrigger.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-DiscargeTrailerTrigger.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-DynamicMountTrigger.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-DynamicMountTrigger.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-Player.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-Player.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-PlayerAndVehicle.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-Trigger-PlayerAndVehicle.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-VehicleCompound.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-VehicleCompound.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/mesh/Physics-VehicleCompoundChild.py
+++ b/addon/i3dio/presets/i3dio/mesh/Physics-VehicleCompoundChild.py
@@ -6,4 +6,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Big.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Big.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 1
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Small.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Small.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Exterior.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Exterior.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-IndoorHud.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-IndoorHud.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Interior.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Interior.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Coronas.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Coronas.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Coronas.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Coronas.py
@@ -9,4 +9,4 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False
+

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Static.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Lights-Static.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Mirrors.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Mirrors.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 1
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-WindowsInside.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-WindowsInside.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-WindowsOutside.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-WindowsOutside.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Default.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Default.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-EmitterShape.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-EmitterShape.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-ExactFillRootNode.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-ExactFillRootNode.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-FillVolume.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-FillVolume.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = True

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-ShadowFocusBox.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-ShadowFocusBox.py
@@ -9,4 +9,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '256'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-StaticObject.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-StaticObject.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = False
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-TrafficVehicle.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-TrafficVehicle.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-AICollisionTrigger.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-AICollisionTrigger.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-DiscargeTrailerTrigger.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-DiscargeTrailerTrigger.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-DynamicMountTrigger.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-DynamicMountTrigger.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-Player.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-Player.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-PlayerAndVehicle.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-Trigger-PlayerAndVehicle.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-VehicleCompound.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-VehicleCompound.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/presets/i3dio/object/mesh/Physics-VehicleCompoundChild.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/Physics-VehicleCompoundChild.py
@@ -14,4 +14,3 @@ obj.data.i3d_attributes.receive_shadows = True
 obj.data.i3d_attributes.non_renderable = True
 obj.data.i3d_attributes.cpu_mesh = '0'
 obj.data.i3d_attributes.decal_layer = 0
-obj.data.i3d_attributes.fill_volume = False

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -46,9 +46,7 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         'nav_mesh_mask': {'name': 'buildNavMeshMask', 'default': '0', 'type': 'HEX'},
         'decal_layer': {'name': 'decalLayer', 'default': 0},
         'vertex_compression_range': {'name': 'vertexCompressionRange', 'default': 'auto',
-                                     'placement': 'IndexedTriangleSet'},
-        'fill_volume': {'name': 'name', 'default': False, 'placement': 'IndexedTriangleSet',
-                        'type': 'OVERRIDE', 'override': 'fillVolumeShape'}
+                                     'placement': 'IndexedTriangleSet'}
     }
 
     casts_shadows: BoolProperty(
@@ -149,13 +147,6 @@ class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
         default=i3d_map['vertex_compression_range']['default']
     )
 
-    fill_volume: BoolProperty(
-        name="Fill Volume",
-        description="Check this if the object is meant to be a fill volume, since this requires some special naming of "
-                    "the IndexedTriangleSet in the i3d file.",
-        default=i3d_map['fill_volume']['default']
-    )
-
     bounding_volume_object: PointerProperty(
         name="Bounding Volume Object",
         description="The object used to calculate bvCenter and bvRadius. "
@@ -227,7 +218,6 @@ class I3D_IO_PT_shape_attributes(Panel):
         op.used_bits = 8
         layout.prop(mesh.i3d_attributes, "decal_layer")
         layout.prop(mesh.i3d_attributes, "vertex_compression_range")
-        layout.prop(mesh.i3d_attributes, 'fill_volume')
 
         header, panel = layout.panel('i3d_bounding_volume', default_closed=False)
         header.label(text="I3D Bounding Volume")


### PR DESCRIPTION
The 'fill_volume' property was used to force 'fillVolumeShape' as the IndexedTriangleSet name.
However, this hasn't been a requirement since Farming Simulator 19, so it is safe to remove for FS25.