### PR TITLE
refactor(exporter): remove double deferred_constraints call and move add_animation to main export func

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -100,6 +100,9 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
             for shape_to_process in i3d.deferred_shapes_to_populate:
                 shape_to_process.process_and_write_mesh_data()
 
+        if i3d.anim_links:
+            i3d.add_animations()
+
         i3d.export_to_i3d_file()
 
         if operator.binarize_i3d:
@@ -198,12 +201,6 @@ def _export(i3d: I3D, objects: List[BlenderObject], sort_alphabetical: bool = Tr
 
     for blender_object in objects_to_export:
         _add_object_to_i3d(i3d, blender_object)
-
-    if i3d.deferred_constraints:
-        _process_deferred_constraints(i3d)
-
-    if i3d.anim_links:
-        i3d.add_animations()
 
 
 def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = None) -> None:


### PR DESCRIPTION
Just some stuff I didn't notice during merging I guess