### PR TITLE
fix(file): allow relative paths outside blend file folder

### DIFF
--- a/addon/i3dio/node_classes/file.py
+++ b/addon/i3dio/node_classes/file.py
@@ -63,22 +63,22 @@ class File(Node):
         - Other files are copied if copy_files is enabled.
         - Otherwise, relative to blend or absolute.
         """
-        filepath_export = utility.as_export_path(self.blender_path)
-        self.resolved_path = Path(filepath_export)
-
-        if filepath_export.startswith('$data'):
+        if self.blender_path.startswith('$data'):
             # Game asset, always reference with $data prefix and never copy
+            self.resolved_path = Path(self.blender_path)
             self.logger.info(f"Resolved filepath as FS data: {self.resolved_path}")
             return
 
         if self.i3d.settings.get('copy_files', False):
             self._copy_file()
-        else:
-            self.logger.info(f"Resolved filepath: {self.resolved_path}")
-            if self.resolved_path.is_absolute():
-                self.logger.warning(
-                    f"File {self.blender_path!r} is outside the blend file folder; using absolute path in I3D."
-                )
+            return
+
+        self.resolved_path = utility.as_export_path(self.blender_path)
+        self.logger.info(f"Resolved filepath: {self.resolved_path}")
+        if self.resolved_path.is_absolute():
+            self.logger.warning(
+                f"File {self.blender_path!r} is outside the blend file folder; using absolute path in I3D."
+            )
 
     def _copy_file(self):
         resolved_directory = Path()

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -173,7 +173,7 @@ class Material(Node):
     def _write_texture_to_xml(self, texture_path: str, xml_key: str, bump_depth: float = None) -> None:
         """Handles writing texture file references to XML."""
         if texture_path:
-            self.logger.debug(f"Has {xml_key}: '{utility.as_fs_relative_path(texture_path)}'")
+            self.logger.debug(f"Has {xml_key}: {utility.as_fs_relative_path(texture_path).as_posix()!r}")
             file_id = self.i3d.add_file_image(texture_path)
             self.xml_elements[xml_key] = xml_i3d.SubElement(self.element, xml_key)
             self._write_attribute('fileId', file_id, xml_key)

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -96,6 +96,9 @@ def as_export_path(filepath: str) -> Path:
     blend_dir = Path(bpy.data.filepath).parent.resolve()
     target_path = Path(bpy.path.abspath(filepath)).resolve(strict=False)
     try:
+        # NOTE: Path.relative_to (pathlib) does not support paths outside its base location before Python 3.12
+        # https://docs.python.org/3.12/library/pathlib.html#pathlib.PurePath.relative_to
+        # Blender will remain on Python 3.11 until 2026 https://vfxplatform.com/ so use os.path.relpath until then
         return Path(os.path.relpath(str(target_path), str(blend_dir)))
     except ValueError:
         return target_path  # Happens if on another drive

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -8,6 +8,7 @@ import math
 import mathutils
 import bpy
 from pathlib import Path
+import os
 import re
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ def vector_compare(a: mathutils.Vector, b: mathutils.Vector, epsilon: float = 0.
     return True
 
 
-def as_fs_relative_path(filepath: str) -> str:
+def as_fs_relative_path(filepath: str) -> Path:
     """
     Checks if a filepath is relative to the FS data directory
 
@@ -62,13 +63,13 @@ def as_fs_relative_path(filepath: str) -> str:
         fs_data_path = Path(bpy.path.abspath(fs_data_pref)).resolve(strict=False)
         try:  # Return $data-prefixed path if inside FS data directory
             relative_to_fs = target_path.relative_to(fs_data_path)
-            return (Path('$data') / relative_to_fs).as_posix()
+            return (Path('$data') / relative_to_fs)
         except ValueError:
             pass  # Not inside FS data directory
-    return target_path.as_posix()
+    return target_path
 
 
-def as_export_path(filepath: str) -> str:
+def as_export_path(filepath: str) -> Path:
     """
     Resolves the export path for a file, for compatibility with Giants Editor and modding workflows.
 
@@ -81,23 +82,23 @@ def as_export_path(filepath: str) -> str:
         filepath (str): The path to the file, as used or stored by/in Blender.
 
     Returns:
-        str: The resolved export path (either $data-relative, relative to blend file, or absolute).
+        Path: The resolved path, either as a relative path (to the blend file) or an absolute path.
     """
     if filepath.startswith('$data'):
-        # If the path already starts with $data, return it as is (can happen from certain shader textures)
-        return filepath
-    fs_path = as_fs_relative_path(filepath)
-    if fs_path.startswith('$data'):
+        # Already $data-prefixed (can happen from certain shader textures)
+        return Path(filepath)
+
+    # Check if inside FS data directory
+    if (fs_path := as_fs_relative_path(filepath)).parts and fs_path.parts[0] == '$data':
         return fs_path
-    # If under blend file directory, use blend-relative path
+
+    # Try to make path relative to the .blend file
     blend_dir = Path(bpy.data.filepath).parent.resolve()
     target_path = Path(bpy.path.abspath(filepath)).resolve(strict=False)
     try:
-        rel = target_path.relative_to(blend_dir)
-        return rel.as_posix()  # Relative to blend file directory
+        return Path(os.path.relpath(str(target_path), str(blend_dir)))
     except ValueError:
-        pass  # Not inside blend file directory
-    return target_path.as_posix()  # Absolute path, as a last resort
+        return target_path  # Happens if on another drive
 
 
 def sort_blender_objects_by_name(objects: List[BlenderObject]) -> List[BlenderObject]:


### PR DESCRIPTION
pathlib.relative_to did not properly support navigation up directories (e.g., '../shared/tex.png'), so now use os.path.relpath.

The path utility functions now return Path objects instead of strings for better clearity.