### PR TITLE
fix(merge group): remove sorting of skin bind node IDs

### DIFF
--- a/addon/i3dio/node_classes/merge_group.py
+++ b/addon/i3dio/node_classes/merge_group.py
@@ -37,7 +37,6 @@ class MergeGroupRoot(ShapeNode):
         """Adds a node ID to the list for skin bind nodes."""
         if node_id not in self.skin_bind_node_ids:
             self.skin_bind_node_ids.append(node_id)
-            self.skin_bind_node_ids.sort()
             id_string = " ".join(map(str, self.skin_bind_node_ids))
             self._write_attribute('skinBindNodeIds', id_string)
             self.logger.debug(f"Registered skin bind ID {node_id} for MergeGroup {self.merge_group_name!r}")


### PR DESCRIPTION
Mistake in earlier commit, skin bind node ids should of course not be sorted... This will cause the bindings to be mixed up in the final i3d. When sorted the node will be the same, but what its bind to/visually move in GE can potentially be something else and thats obviously not something we want! 🙈