### PR TITLE
fix(file): prevent game path ($data) files from being copied

### DIFF
--- a/addon/i3dio/node_classes/file.py
+++ b/addon/i3dio/node_classes/file.py
@@ -63,17 +63,17 @@ class File(Node):
         - Other files are copied if copy_files is enabled.
         - Otherwise, relative to blend or absolute.
         """
-        if self.blender_path.startswith('$data'):
+        self.resolved_path = utility.as_export_path(self.blender_path)
+
+        if str(self.resolved_path).startswith('$data'):
             # Game asset, always reference with $data prefix and never copy
-            self.resolved_path = Path(self.blender_path)
-            self.logger.info(f"Resolved filepath as FS data: {self.resolved_path}")
+            self.logger.info(f"Resolved as FS $data path: {self.resolved_path}")
             return
 
         if self.i3d.settings.get('copy_files', False):
             self._copy_file()
             return
 
-        self.resolved_path = utility.as_export_path(self.blender_path)
         self.logger.info(f"Resolved filepath: {self.resolved_path}")
         if self.resolved_path.is_absolute():
             self.logger.warning(


### PR DESCRIPTION
Paths belonging to the FS data directory are now detected before any copy logic runs, ensuring that base game assets are always referenced with $data and never copied.

This fixes a issue introduced in commit f6c760f, turns out I forgot to test that commit with the copy files option enabled...