### PR TITLE
fix(mesh): avoid applying legacy defaults in new files by marking as migrated

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -228,6 +228,9 @@ class I3D_IO_PT_shape_attributes(Panel):
 @persistent
 def migrate_i3d_property_defaults(dummy) -> None:
     if not bpy.data.filepath:
+        # This is a new, unsaved file. Mark all meshes as 'migrated' to avoid false migration on next file load
+        for mesh in bpy.data.meshes:
+            mesh.i3d_attributes.version = CURRENT_VERSION
         return  # Skip new files
     for mesh in bpy.data.meshes:
         props = mesh.i3d_attributes


### PR DESCRIPTION
If a blend file is new (unsaved), immediately set the property version for all meshes
to avoid overwriting new default values with legacy migration logic on future loads.