### PR TITLE
fix(skinned-mesh): correct bone pose-space export; collapse-aware parenting; unify i3d conversion

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -221,7 +221,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
     # Special handling for collapsed armatures: Unlike Maya, Blender treats armatures differently, so when an armature
     # is collapsed, its children should be reassigned to the armature's parent (or scene root) to maintain hierarchy.
     if isinstance(parent, SkinnedMeshRootNode) and parent.is_collapsed:
-        logger.debug(f"[{obj.name}] is under a collapsed armature. Moving it to the armature's parent.")
+        logger.debug(f"[{obj.name}] is under a collapsed armature. Moving it to the armature's parent or root")
         _parent = parent.parent
 
     type_supported = obj.type in i3d.settings['object_types_to_export']
@@ -342,8 +342,9 @@ def _process_deferred_constraints(i3d: I3D):
         i3d.logger.debug(f"Processing deferred constraint for: {bone_node}, Target: {target_obj}")
         if target_node := i3d.processed_objects.get(target_obj):
             bone_node.reparent(target_node)
+            bone_node.finalize_transform()
         else:
-            i3d.logger.warning(f"Target '{target_obj}' is not processed or not in export list. Skipping.")
+            i3d.logger.warning(f"Target {target_obj!r} is not processed or not in export list. Skipping.")
 
 
 def _binarize_i3d(filepath: str, operator, logger: logging.Logger):

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -87,9 +87,10 @@ class SceneGraphNode(Node):
                  i3d: I3D,
                  parent: SceneGraphNode | None = None,
                  ):
-        self.children = []
+        self.children: list[SceneGraphNode] = []
         self.blender_object = blender_object
         self.parent = parent
+        self.defer_transform: bool = False  # bones may change parent which makes the first calculated transform invalid
         self.xml_elements: Dict[str, Union[xml_i3d.XML_Element, None]] = {'Node': None}
 
         self._name = self.blender_object.name
@@ -166,7 +167,7 @@ class SceneGraphNode(Node):
             self.logger.debug(f"Blender parent matches exporter parent ({export_parent_obj.name}): using local matrix")
             return obj.matrix_local.copy()
         if export_parent_obj is None:
-            self.logger.warning(
+            self.logger.debug(
                 "exporter parent exists, but exporter_parent_obj is None. "
                 "Defaulting to world-space transform. Possible broken hierarchy."
             )
@@ -233,27 +234,52 @@ class SceneGraphNode(Node):
     def populate_xml_element(self):
         self._write_properties()
         self._write_user_attributes()
-        self._add_transform_to_xml_element(self._transform_for_conversion)
+        if not self.defer_transform:
+            self._add_transform_to_xml_element(self._transform_for_conversion)
 
-    def add_child(self, node: SceneGraphNode):
-        self.children.append(node)
+    def finalize_transform(self):
+        if self.defer_transform:
+            self._add_transform_to_xml_element(self._transform_for_conversion)
+            self.defer_transform = False
 
-    def remove_child(self, node: SceneGraphNode):
+    def add_child(self, child_node: SceneGraphNode):
+        if child_node in self.children:
+            return
+        self.children.append(child_node)
+
+    def remove_child(self, child_node: SceneGraphNode):
         """Removes a child node from the children list."""
         try:
-            self.children.remove(node)
+            self.children.remove(child_node)
         except ValueError:
             self.logger.warning(
-                f"Attempted to remove child '{node.name}' from parent '{self.name}', "
+                f"Attempted to remove child {child_node.name!r} from parent {self.name!r}, "
                 "but it was not found in the children list."
             )
+
+    def reparent(self, new_parent: SceneGraphNode | None) -> None:
+        # Detach from current Python/XML parent if any
+        if self.parent is not None:
+            self.parent.remove_child(self)
+            try:
+                self.parent.element.remove(self.element)
+            except Exception:
+                pass
+
+        self.parent = new_parent
+        if new_parent:
+            new_parent.add_child(self)
+            new_parent.element.append(self.element)
+        else:
+            self.i3d.scene_root_nodes.append(self)
+            self.i3d.xml_elements['Scene'].append(self.element)
 
     def add_i3d_mapping_to_xml(self):
         try:
             if getattr(self.blender_object.i3d_mapping, 'is_mapped'):
                 self.i3d.i3d_mapping.append(self)
         except AttributeError:
-            pass
+            self.logger.debug("XML detach skipped (element not present under previous parent)")
 
 
 class TransformGroupNode(SceneGraphNode):
@@ -266,9 +292,7 @@ class TransformGroupNode(SceneGraphNode):
     @property
     def _transform_for_conversion(self) -> mathutils.Matrix:
         try:
-            conversion_matrix = (
-                self.i3d.conversion_matrix @ self._get_object_matrix() @ self.i3d.conversion_matrix_inv
-            )
+            conversion_matrix = self.i3d.to_i3d(self._get_object_matrix())
         except AttributeError:
             self.logger.info("is a Collection and it will be exported as a transformgroup with default transform")
             conversion_matrix = None
@@ -308,7 +332,7 @@ class LightNode(SceneGraphNode):
 
     @property
     def _transform_for_conversion(self) -> mathutils.Matrix:
-        return self.i3d.conversion_matrix @ self._get_object_matrix()
+        return self.i3d.to_i3d_forward(self._get_object_matrix())
 
     def populate_xml_element(self):
         super().populate_xml_element()
@@ -322,7 +346,7 @@ class CameraNode(SceneGraphNode):
 
     @property
     def _transform_for_conversion(self) -> mathutils.Matrix:
-        return self.i3d.conversion_matrix @ self._get_object_matrix()
+        return self.i3d.to_i3d_forward(self._get_object_matrix())
 
     def populate_xml_element(self):
         camera = self.blender_object.data

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -264,7 +264,7 @@ class SceneGraphNode(Node):
             try:
                 self.parent.element.remove(self.element)
             except Exception:
-                pass
+                self.logger.debug("XML detach skipped (element not present under previous parent)")
 
         self.parent = new_parent
         if new_parent:
@@ -279,7 +279,7 @@ class SceneGraphNode(Node):
             if getattr(self.blender_object.i3d_mapping, 'is_mapped'):
                 self.i3d.i3d_mapping.append(self)
         except AttributeError:
-            self.logger.debug("XML detach skipped (element not present under previous parent)")
+            pass
 
 
 class TransformGroupNode(SceneGraphNode):

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -900,7 +900,7 @@ class ShapeNode(SceneGraphNode):
 
     @property
     def _transform_for_conversion(self) -> mathutils.Matrix:
-        return self.i3d.conversion_matrix @ self._get_object_matrix() @ self.i3d.conversion_matrix_inv
+        return self.i3d.to_i3d(self._get_object_matrix())
 
     def is_instance(self) -> bool:
         """Return True if this shape node is an instance (not the source/original) of a processed mesh."""


### PR DESCRIPTION
After a reported issue related to bone animations. I detected more issues with armature/bone logic.

- Align animation bone matrix conversions with static/rest bone conversion in SkinnedMeshBoneNode
- Handle collapsed armatures without adding it to xml/i3d. Keep Python parent so non-bone children attach to correct parent
- Defer transform for armature/bone and finalize it when the parent(s) are known.
- Add I3D.to_i3d()/to_i3d_forward for more easier conversion

At some point it would be really nice to get some proper "tests", so we can avoid stuff like this from breaking during refactors/new features etc😅 That said, a lot of the code that complicates this kind of processing will also be greatly simplified when ever we "change the order of export". Make the entire "tree"/"SceneGraph" first and then after that write all data related to final I3D/XML (transforms, attributes etc etc).