### PR TITLE
refactor(node): replace chained descriptor pattern with class constants

### DIFF
--- a/addon/i3dio/node_classes/file.py
+++ b/addon/i3dio/node_classes/file.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 import logging
 from pathlib import Path
 import shutil
+from typing import ClassVar
 import bpy
 
 from .node import Node
@@ -15,9 +16,9 @@ from ..i3d import I3D
 
 
 class File(Node):
-    ELEMENT_TAG = 'File'
-    NAME_FIELD_NAME = 'filename'
-    ID_FIELD_NAME = 'fileId'
+    ELEMENT_TAG: ClassVar[str] = 'File'
+    NAME_FIELD_NAME: ClassVar[str] = 'filename'
+    ID_FIELD_NAME: ClassVar[str] = 'fileId'
 
     @property
     @classmethod

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -1,4 +1,5 @@
 import math
+from typing import ClassVar
 import bpy
 import mathutils
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper, ShaderImageTextureWrapper
@@ -10,9 +11,9 @@ from .node import Node
 
 
 class Material(Node):
-    ELEMENT_TAG = 'Material'
-    NAME_FIELD_NAME = 'name'
-    ID_FIELD_NAME = 'materialId'
+    ELEMENT_TAG: ClassVar[str] = 'Material'
+    NAME_FIELD_NAME: ClassVar[str] = 'name'
+    ID_FIELD_NAME: ClassVar[str] = 'materialId'
 
     def __init__(self, id_: int, i3d: I3D, blender_material: bpy.types.Material):
         self.blender_material = blender_material

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -1,7 +1,8 @@
 from __future__ import annotations  # Enables python 4.0 annotation typehints fx. class self-referencing
 from abc import (ABC, abstractmethod)
+from inspect import isabstract
 import logging
-from typing import (Union, Dict)
+from typing import ClassVar
 import math
 import mathutils
 import bpy
@@ -12,25 +13,20 @@ from ..i3d import I3D
 
 
 class Node(ABC):
-    @property
-    @classmethod
-    @abstractmethod
-    def ELEMENT_TAG(cls):  # Every node type has a certain tag in the i3d-file fx. 'Shape' or 'Light'
-        return NotImplementedError
+    ELEMENT_TAG: ClassVar[str]
+    ID_FIELD_NAME: ClassVar[str]
+    NAME_FIELD_NAME: ClassVar[str]
 
-    @property
-    @classmethod
-    @abstractmethod
-    def ID_FIELD_NAME(cls):  # The name of the id tag changes from node to node, but it is still an ID
-        return NotImplementedError
+    def __init_subclass__(cls, **kwargs):
+        """Ensures that all subclasses define the required class variables."""
+        if isabstract(cls):
+            return  # Skip abstract base classes
+        super().__init_subclass__(**kwargs)
+        missing = [var for var in ('ELEMENT_TAG', 'ID_FIELD_NAME', 'NAME_FIELD_NAME') if not hasattr(cls, var)]
+        if missing:
+            raise TypeError(f"{cls.__name__} must define: {', '.join(missing)}")
 
-    @property
-    @classmethod
-    @abstractmethod
-    def NAME_FIELD_NAME(cls):  # The name of the name tag can change from node to node
-        return NotImplementedError
-
-    def __init__(self, id_: int, i3d: I3D, parent: Union[Node, None] = None):
+    def __init__(self, id_: int, i3d: I3D, parent: Node | None = None):
         self.id = id_
         self.i3d = i3d
         self.parent = parent
@@ -79,8 +75,8 @@ class Node(ABC):
 
 
 class SceneGraphNode(Node):
-    NAME_FIELD_NAME = 'name'
-    ID_FIELD_NAME = 'nodeId'
+    NAME_FIELD_NAME: ClassVar[str] = 'name'
+    ID_FIELD_NAME: ClassVar[str] = 'nodeId'
 
     def __init__(self, id_: int,
                  blender_object: bpy.types.Object | bpy.types.Collection | None,
@@ -91,7 +87,7 @@ class SceneGraphNode(Node):
         self.blender_object = blender_object
         self.parent = parent
         self.defer_transform: bool = False  # bones may change parent which makes the first calculated transform invalid
-        self.xml_elements: Dict[str, Union[xml_i3d.XML_Element, None]] = {'Node': None}
+        self.xml_elements: dict[str, xml_i3d.XML_Element | None] = {'Node': None}
 
         self._name = self.blender_object.name
         prefix = i3d.settings.get('object_sorting_prefix', "")
@@ -119,7 +115,7 @@ class SceneGraphNode(Node):
         return self._name
 
     @property
-    def element(self) -> Union[xml_i3d.XML_Element, None]:
+    def element(self) -> xml_i3d.XML_Element | None:
         return self.xml_elements['Node']
 
     @element.setter
@@ -186,11 +182,11 @@ class SceneGraphNode(Node):
 
     @property
     @abstractmethod
-    def _transform_for_conversion(self) -> Union[mathutils.Matrix, None]:
+    def _transform_for_conversion(self) -> mathutils.Matrix | None:
         """Different node types have different requirements for getting converted into i3d coordinates"""
         raise NotImplementedError
 
-    def _add_transform_to_xml_element(self, object_transform: Union[mathutils.Matrix, None]) -> None:
+    def _add_transform_to_xml_element(self, object_transform: mathutils.Matrix | None) -> None:
         """This method checks the parent and adjusts the transform before exporting"""
         if object_transform is None:
             # This essentially sets the entire transform to be default. Since GE loads defaults when no data is present.
@@ -285,14 +281,14 @@ class SceneGraphNode(Node):
 
 
 class TransformGroupNode(SceneGraphNode):
-    ELEMENT_TAG = 'TransformGroup'
+    ELEMENT_TAG: ClassVar[str] = 'TransformGroup'
 
     def __init__(self, id_: int, empty_object: bpy.types.Object | bpy.types.Collection,
                  i3d: I3D, parent: SceneGraphNode | None = None):
         super().__init__(id_=id_, blender_object=empty_object, i3d=i3d, parent=parent)
 
     @property
-    def _transform_for_conversion(self) -> mathutils.Matrix:
+    def _transform_for_conversion(self) -> mathutils.Matrix | None:
         try:
             conversion_matrix = self.i3d.to_i3d(self._get_object_matrix())
         except AttributeError:
@@ -327,7 +323,7 @@ class TransformGroupNode(SceneGraphNode):
 
 
 class LightNode(SceneGraphNode):
-    ELEMENT_TAG = 'Light'
+    ELEMENT_TAG: ClassVar[str] = 'Light'
 
     def __init__(self, id_: int, light_object: bpy.types.Object, i3d: I3D, parent: SceneGraphNode or None = None):
         super().__init__(id_=id_, blender_object=light_object, i3d=i3d, parent=parent)
@@ -341,7 +337,7 @@ class LightNode(SceneGraphNode):
 
 
 class CameraNode(SceneGraphNode):
-    ELEMENT_TAG = 'Camera'
+    ELEMENT_TAG: ClassVar[str] = 'Camera'
 
     def __init__(self, id_: int, camera_object: bpy.types.Object, i3d: I3D, parent: SceneGraphNode or None = None):
         super().__init__(id_=id_, blender_object=camera_object, i3d=i3d, parent=parent)

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -13,10 +13,6 @@ from ..i3d import I3D
 
 
 class Node(ABC):
-    ELEMENT_TAG: ClassVar[str]
-    ID_FIELD_NAME: ClassVar[str]
-    NAME_FIELD_NAME: ClassVar[str]
-
     def __init_subclass__(cls, **kwargs):
         """Ensures that all subclasses define the required class variables."""
         if isabstract(cls):

--- a/addon/i3dio/node_classes/shape.py
+++ b/addon/i3dio/node_classes/shape.py
@@ -1,6 +1,7 @@
 import logging
 import dataclasses
 from dataclasses import dataclass
+from typing import ClassVar
 import numpy as np
 import mathutils
 from collections import OrderedDict, ChainMap, defaultdict
@@ -98,9 +99,9 @@ class IndexedTriangleSet(Node):
     IndexedTriangleSet element in the I3D file. Handles mesh data extraction, attribute packing, material assignment,
     vertex deduplication, and final XML output.
     """
-    ELEMENT_TAG = 'IndexedTriangleSet'
-    NAME_FIELD_NAME = 'name'
-    ID_FIELD_NAME = 'shapeId'
+    ELEMENT_TAG: ClassVar[str] = 'IndexedTriangleSet'
+    NAME_FIELD_NAME: ClassVar[str] = 'name'
+    ID_FIELD_NAME: ClassVar[str] = 'shapeId'
 
     def __init__(self, id_: int, i3d: I3D, evaluated_mesh: EvaluatedMesh, *,
                  shape_name: str | None = None,
@@ -837,9 +838,9 @@ class EvaluatedNurbsCurve:
 
 
 class NurbsCurve(Node):
-    ELEMENT_TAG = 'NurbsCurve'
-    NAME_FIELD_NAME = 'name'
-    ID_FIELD_NAME = 'shapeId'
+    ELEMENT_TAG: ClassVar[str] = 'NurbsCurve'
+    NAME_FIELD_NAME: ClassVar[str] = 'name'
+    ID_FIELD_NAME: ClassVar[str] = 'shapeId'
 
     def __init__(self, id_: int, i3d: I3D, evaluated_curve_data: EvaluatedNurbsCurve, shape_name: str | None = None):
         self.id: int = id_
@@ -911,7 +912,7 @@ class NurbsCurve(Node):
 
 
 class ShapeNode(SceneGraphNode):
-    ELEMENT_TAG = 'Shape'
+    ELEMENT_TAG: ClassVar[str] = 'Shape'
 
     def __init__(self, id_: int, shape_object: bpy.types.Object | None, i3d: I3D, parent: SceneGraphNode | None = None):
         self.shape_id: int | None = None


### PR DESCRIPTION
Python 3.11 deprecates chaining descriptors (e.g. @property + @classmethod).
Move ELEMENT_TAG/ID_FIELD_NAME/NAME_FIELD_NAME to ClassVar[str] constants and enforce their presence via __init_subclass__ (abstract classes skipped).
(No functional changes)