### PR TITLE
feat(binarizer): add structured logging of i3dConverter output

### DIFF
--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -371,22 +371,48 @@ def _binarize_i3d(filepath: str, operator, logger: logging.Logger):
                 '-gamePath', f"{game_path}/"
             ],
             timeout=BINARIZER_TIMEOUT_IN_SECONDS,
-            check=True,
+            check=False,  # inspect stdout even on non-zero exit code
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT
         )
+        raw = conversion_result.stdout or ""
+        lines = [ln.rstrip("\r\n") for ln in raw.splitlines() if ln.strip()]
+
+        # Some lines could be repeated multiple times, collapse them
+        collapsed: list[str] = []
+        last = None
+        for ln in lines:
+            if ln != last:
+                collapsed.append(ln)
+            last = ln
+
+        _UNIMPORTANT = ("render system", "driver: null", "nullconsoledevice initialized", "i3d contains non-binary")
+        def _emit(line: str) -> None:
+            msg = line.rstrip()
+            low = msg.lower().strip()
+            if any(s in low for s in _UNIMPORTANT):
+                return
+            if low.startswith("error:"):
+                logger.error(f"  {msg}", stacklevel=2)
+            elif low.startswith("warning:"):
+                logger.warning(msg, stacklevel=2)
+            else:
+                logger.info(f"   {msg}", stacklevel=2)
+        for line in collapsed:
+            _emit(line)
+
+        if conversion_result.returncode != 0:  # Non-zero exit
+            operator.report({'ERROR'}, "Binarization failed. See log for details.")
+            return
+        logger.info(f'Finished binarization of "{filepath}"')
+        operator.report({'INFO'}, "Binarization completed successfully.")
+
     except FileNotFoundError:
         logger.error(f"Invalid path to i3dConverter.exe: {converter_exe_path!r}")
     except subprocess.TimeoutExpired as e:
         logger.error(f"i3dConverter.exe timed out after {BINARIZER_TIMEOUT_IN_SECONDS} seconds. Output: {e.output!r}")
-    except subprocess.CalledProcessError as e:
-        logger.error(f"i3dConverter.exe failed to run with error code: {e.returncode}")
-    else:
-        error_messages = [f"\t{line}" for line in conversion_result.stdout.split('\n') if line.startswith("Error:")]
-        if error_messages:
-            logger.error("i3dConverter.exe produced errors:\n" + '\n'.join(error_messages))
-            operator.report({'ERROR'}, "i3dConverter.exe reported errors. See log for details.")
-        else:
-            logger.info(f'Finished binarization of "{filepath}"')
-            operator.report({'INFO'}, "Binarization completed successfully.")
+        operator.report({'ERROR'}, "Binarization timed out. See log for details.")
+    except Exception:
+        logger.exception("Unexpected error while running i3dConverter.exe")
+        operator.report({'ERROR'}, "Binarization crashed. See log for details.")


### PR DESCRIPTION
Previousily only fatal errors were logged. This change will now capture all output from i3dConverter (ignores some known stuff thats irrelevant).

**Example of a split shape (tree trunk) with to high vertex count:**
```
bl_ext.user_default.i3dio.exporter:_add_object_to_i3d:DEBUG: [Cube] no more children to process in object
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO: Starting binarization of 'C:\\Users\\\\Desktop\\random\\Untitled.i3d'
bl_ext.user_default.i3dio.exporter:_binarize_i3d:WARNING: Warning: Failed to create splittable mesh 'Cube.002'. Maximum 65536 vertices are allowed.
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO:    C:/Users/ksjoe/Desktop/random/Untitled.i3d (623.67 ms)
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO:    Scenefile 'C:/Users//Desktop/random/Untitled.i3d' saved in 42.353800 ms at Tue Oct 14 23:10:34 2025.
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO: Finished binarization of "C:\Users\\Desktop\random\Untitled.i3d"
bl_ext.user_default.i3dio.exporter:export_blend_to_i3d:INFO: Export took 4.867 seconds
```

<img width="1097" height="231" alt="image" src="https://github.com/user-attachments/assets/215e42f1-a90b-4666-aed6-79e1d00adecb" />

**Split shape failed due to non-manifold edges (inverted face):**
```
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO: Starting binarization of 'C:\\Users\\ksjoe\\Desktop\\random\\Untitled.i3d'
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO:    Topology: Mesh contains non-manifold edges
bl_ext.user_default.i3dio.exporter:_binarize_i3d:WARNING: Warning: Failed to create splittable mesh 'Cube.002'.
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO:    C:/Users/ksjoe/Desktop/random/Untitled.i3d (0.46 ms)
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO:    Scenefile 'C:/Users/ksjoe/Desktop/random/Untitled.i3d' saved in 1.481300 ms at Tue Oct 14 23:21:57 2025.
bl_ext.user_default.i3dio.exporter:_binarize_i3d:INFO: Finished binarization of "C:\Users\ksjoe\Desktop\random\Untitled.i3d"
bl_ext.user_default.i3dio.exporter:export_blend_to_i3d:INFO: Export took 0.028 seconds
```

<img width="1077" height="147" alt="image" src="https://github.com/user-attachments/assets/bb8c0926-a286-40ea-b239-045fdf26a015" />
