### PR TITLE
refactor(presets): drop custom AddPresetBase

### DIFF
--- a/addon/i3dio/ui/light.py
+++ b/addon/i3dio/ui/light.py
@@ -3,7 +3,7 @@ from bpy.types import (
     Operator,
     Panel
 )
-
+from bl_operators.presets import AddPresetBase
 from bpy.props import (
     PointerProperty,
     FloatProperty,
@@ -331,7 +331,7 @@ class I3D_IO_PT_Light_Presets(presets.PresetPanel, Panel):
         
 
 @register
-class I3D_IO_OT_Light_Add_Preset(presets.AddPresetBase, Operator):
+class I3D_IO_OT_Light_Add_Preset(AddPresetBase, Operator):
     bl_idname = "i3dio.add_light_preset"
     bl_label = "Add a Light Preset"
     preset_menu = "I3D_IO_PT_Light_Presets"

--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -3,7 +3,7 @@ from bpy.types import (
     Operator,
     Panel
 )
-
+from bl_operators.presets import AddPresetBase
 from bpy.props import (
     StringProperty,
     BoolProperty,
@@ -172,7 +172,7 @@ class I3D_IO_PT_Mesh_Presets(presets.PresetPanel, Panel):
 
 
 @register
-class I3D_IO_OT_Mesh_Add_Preset(presets.AddPresetBase, Operator):
+class I3D_IO_OT_Mesh_Add_Preset(AddPresetBase, Operator):
     bl_idname = "i3dio.add_mesh_preset"
     bl_label = "Add a Mesh Preset"
     preset_menu = "I3D_IO_PT_Mesh_Presets"

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -3,6 +3,7 @@ from bpy.types import (
     Operator,
     Panel
 )
+from bl_operators.presets import AddPresetBase
 from bpy.app.handlers import (
     persistent,
     load_post
@@ -1103,7 +1104,7 @@ class I3D_IO_PT_Object_Presets(presets.PresetPanel, Panel):
 
 
 @register
-class I3D_IO_OT_Object_Add_Preset(presets.AddPresetBase, Operator):
+class I3D_IO_OT_Object_Add_Preset(AddPresetBase, Operator):
     bl_idname = "i3dio.add_object_preset"
     bl_label = "Add an Object Preset"
     preset_menu = "I3D_IO_PT_Object_Presets"

--- a/addon/i3dio/ui/presets.py
+++ b/addon/i3dio/ui/presets.py
@@ -1,29 +1,16 @@
 import bpy
-from bl_operators.presets import AddPresetBase as BlenderAddPresetBase
 from bl_ui.utils import PresetPanel as BlenderPresetPanel
 from pathlib import PurePath
-from .. import __package__ as base_package
 from .. import __file__ as base_file_path
 PRESETS_PATH = PurePath(base_file_path).parent
 
 class PresetPanel(BlenderPresetPanel):
-    # Same fix as https://projects.blender.org/blender/blender/commit/4f15c247052b6db49b5226b6c473bdb7b2be6293 because python registered properties,
-    # don't trigger redraws
+    # Same fix as https://projects.blender.org/blender/blender/commit/4f15c247052b6db49b5226b6c473bdb7b2be6293
+    # because python registered properties, don't trigger redraws
     def __del__(self):
         # Sometimes context.area is null when this destructor is called 
         if bpy.context.area:
             bpy.context.area.tag_redraw()
-
-class AddPresetBase(BlenderAddPresetBase):
-    # A hack because `_is_path_readonly` only considers the builtin Blender path or extension paths as read-only and not addons
-    # https://github.com/blender/blender/blob/49af320b7f2190607ebb400b47ba0a1dfa0f675e/scripts/startup/bl_operators/presets.py#L225
-    # Deprecate: Once the addon is converted to an extension
-    def remove(self, context, filepath):
-        if PRESETS_PATH in PurePath(filepath).parents:
-            self.report({'WARNING'}, f"Unable to remove {base_package} default preset")
-        else:
-            import os
-            os.remove(filepath)
 
 def PresetSubdir():
     return PurePath('i3dio')


### PR DESCRIPTION
Now that the add-on is an extension, we can remove the custom AddPresetBase class since the "built-in" presets are now "protected" by _is_path_readonly check.