### PR TITLE
fix(shader-picker): remove double colon from mat slot name label

### DIFF
--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -330,7 +330,7 @@ class I3D_IO_PT_material_shader(Panel):
         box.prop(material.i3d_attributes, 'use_material_slot_name')
         row = box.row()
         row.enabled = material.i3d_attributes.use_material_slot_name
-        row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name:", placeholder=material.name)
+        row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name", placeholder=material.name)
 
         layout.separator(type='LINE')
 


### PR DESCRIPTION
<img width="390" height="78" alt="image" src="https://github.com/user-attachments/assets/de1b6096-bb77-48a6-b780-1700a1c1ecb6" />
<img width="401" height="77" alt="image" src="https://github.com/user-attachments/assets/f15f0d55-bdde-4d8a-b60e-6d41089912c5" />
