### PR TITLE
fix(ui): correct panel method call for split type panel in rigid body attributes

### DIFF
--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -839,7 +839,7 @@ def draw_rigid_body_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.t
         panel.prop(i3d_attributes, 'solver_iteration_count')
 
         # Split Type Panel
-        header, panel = layout.panel('i3d_split_type_panel', default_closed=True)
+        header, panel = panel.panel('i3d_split_type_panel', default_closed=True)
         header.label(text="Split Type")
         header.emboss = 'NONE'
         header.menu(I3D_IO_MT_split_type_presets.bl_idname, icon='PRESET', text="")


### PR DESCRIPTION
Make Split Type panel part of rigid body panel instead of main "layout".

| **Before** | **After** |
|-----------|-----------|
| <img width="350" src="https://github.com/user-attachments/assets/e7e6a1ff-ebe2-4e25-9205-9a55f17c8c07" /> | <img width="350" src="https://github.com/user-attachments/assets/494d5e3f-a835-47fa-bb9e-8031daf1fce8" /> |

