### PR TITLE
feat(merge-children): add reverse order option for child mesh processing

### DIFF
--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -58,11 +58,14 @@ class MergeChildrenRoot(ShapeNode):
         apply_child_transforms = root_obj.i3d_merge_children.apply_transforms
         root_world_matrix = root_obj.matrix_world
         interpolation_steps = root_obj.i3d_merge_children.interpolation_steps
+        child_objects = sort_blender_objects_by_outliner_ordering(root_obj.children)
+        if root_obj.i3d_merge_children.reverse_order:
+            child_objects.reverse()
 
         self.logger.debug(f"Merging child meshes (Interpolation steps: {interpolation_steps})")
 
         g_value_index = 0
-        for child in sort_blender_objects_by_outliner_ordering(root_obj.children):
+        for child in child_objects:
             # Both mesh and non-mesh objects are processed; non-mesh objects only affect interpolation steps.
             # Generic value for this child and its descendants.
             generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -1,9 +1,10 @@
-import mathutils
 import bpy
+import mathutils
 
-from .node import SceneGraphNode
-from .shape import (ShapeNode, EvaluatedMesh)
 from ..i3d import I3D
+from ..utility import sort_blender_objects_by_outliner_ordering
+from .node import SceneGraphNode
+from .shape import EvaluatedMesh, ShapeNode
 
 # Maximum index value for `mergeChildren` objects, used to normalize
 # generic values (g_value) for shaders. This constant is critical for:
@@ -61,7 +62,7 @@ class MergeChildrenRoot(ShapeNode):
         self.logger.debug(f"Merging child meshes (Interpolation steps: {interpolation_steps})")
 
         g_value_index = 0
-        for child in root_obj.children:
+        for child in sort_blender_objects_by_outliner_ordering(root_obj.children):
             # Both mesh and non-mesh objects are processed; non-mesh objects only affect interpolation steps.
             # Generic value for this child and its descendants.
             generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -518,6 +518,15 @@ class I3DMergeChildren(bpy.types.PropertyGroup):
         min=1,
         max=10
     )
+    reverse_order: bpy.props.BoolProperty(
+        name="Reverse Order",
+        description=(
+            "If enabled, child objects are processed in reverse order based on their appearance in the outliner. "
+            "This affects the assignment of generic values used in shaders, "
+            "which can influence rendering order or animation sequences."
+        ),
+        default=False
+    )
 
 
 @register
@@ -963,6 +972,7 @@ def draw_merge_children_attributes(layout: bpy.types.UILayout, i3d_merge_childre
         panel.enabled = i3d_merge_children.enabled
         panel.prop(i3d_merge_children, 'apply_transforms')
         panel.prop(i3d_merge_children, 'interpolation_steps')
+        panel.prop(i3d_merge_children, 'reverse_order')
 
 
 def draw_motion_path_array_attrs(layout: bpy.types.UILayout, i3d_motion_path_array: bpy.types.PropertyGroup) -> None:


### PR DESCRIPTION
Requires #384 

This option might be useful to some, the default behaviour of e.g. the hideByIndex shader feels kind of reversed, so instead of finding the "right" attributes etc to set in the shader or xml, its easier to just reverse the order during export.
<img width="415" height="141" alt="Skjermbilde 2025-12-19 223030" src="https://github.com/user-attachments/assets/f2f0d2dd-2ee1-4136-952a-88d9cfbb8fa4" />
