### PR TITLE
feat: manual base texture selection before read textures from shading nodes

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -45,52 +45,84 @@ class Material(Node):
             return self.i3d_attrs.material_slot_name or self.blender_material.name
         return None
 
+    @staticmethod
+    def _path_from_blender_image(image: 'bpy.types.Image | None') -> str | None:
+        """Get filepath from a direct bpy.types.Image reference (used by manual override PointerProperties)."""
+        if not image:
+            return None
+        return image.filepath_from_user() or (image.filepath if image.filepath else None)
+
     def populate_xml_element(self) -> None:
         vehicle_shader = (self.i3d_attrs.shader_name == "vehicleShader")
+
+        # Manual texture overrides take priority over shader node detection.
+        # If a PointerProperty is set, that image is used and node detection is skipped for that slot.
+        override_diffuse  = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_diffuse_map',  None))
+        override_gloss    = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_gloss_map',    None))
+        override_normal   = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_normal_map',   None))
+        override_emissive = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_emissive_map', None))
+
         principled = PrincipledBSDFWrapper(self.blender_material, is_readonly=True)
         bsdf = principled.node_principled_bsdf
 
-        emission_tex_path = self._image_path(principled.emission_color_texture)
+        # EMISSIVE
         skip_diffuse = False
-        if emission_tex_path:
-            self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
+        if override_emissive:
+            self._write_texture_to_xml(override_emissive, 'Emissivemap')
             skip_diffuse = True
-        elif principled.emission_strength > 0:
-            emis_color = (
-                self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
-            )
-            self._write_color(emis_color, 'emissiveColor')
-            skip_diffuse = True
-
-        if not skip_diffuse:
-            base_tex_path = self._image_path(principled.base_color_texture)
-            if base_tex_path:
-                self._write_texture_to_xml(base_tex_path, 'Texture')
-            else:
-                base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
-                self._write_color(base_col, 'diffuseColor')
-
-        normalmap_tex_path = self._image_path(principled.normalmap_texture)
-        if normalmap_tex_path:
-            bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
-            self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
-
-        gloss_path = None
-        if glossnode := self._find_node_by_name('glossmap'):
-            match glossnode.bl_idname:
-                case "ShaderNodeTexImage":
-                    gloss_path = self._image_path(glossnode)
-                case "ShaderNodeSeparateColor":
-                    input = glossnode.inputs['Color']
-                    if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
-                        gloss_path = self._image_path(source)
         else:
-            gloss_path = self._image_path(principled.specular_texture)
+            emission_tex_path = self._image_path(principled.emission_color_texture)
+            if emission_tex_path:
+                self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
+                skip_diffuse = True
+            elif principled.emission_strength > 0:
+                emis_color = (
+                    self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
+                )
+                self._write_color(emis_color, 'emissiveColor')
+                skip_diffuse = True
 
-        if gloss_path:
-            self._write_texture_to_xml(gloss_path, 'Glossmap')
-        elif not gloss_path and not vehicle_shader:
-            self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
+        # DIFFUSE
+        if not skip_diffuse:
+            if override_diffuse:
+                self._write_texture_to_xml(override_diffuse, 'Texture')
+            else:
+                base_tex_path = self._image_path(principled.base_color_texture)
+                if base_tex_path:
+                    self._write_texture_to_xml(base_tex_path, 'Texture')
+                else:
+                    base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
+                    self._write_color(base_col, 'diffuseColor')
+
+        # NORMAL MAP
+        if override_normal:
+            self._write_texture_to_xml(override_normal, 'Normalmap')
+        else:
+            normalmap_tex_path = self._image_path(principled.normalmap_texture)
+            if normalmap_tex_path:
+                bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
+                self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
+
+        # GLOSS MAP
+        if override_gloss:
+            self._write_texture_to_xml(override_gloss, 'Glossmap')
+        else:
+            gloss_path = None
+            if glossnode := self._find_node_by_name('glossmap'):
+                match glossnode.bl_idname:
+                    case "ShaderNodeTexImage":
+                        gloss_path = self._image_path(glossnode)
+                    case "ShaderNodeSeparateColor":
+                        input = glossnode.inputs['Color']
+                        if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
+                            gloss_path = self._image_path(source)
+            else:
+                gloss_path = self._image_path(principled.specular_texture)
+
+            if gloss_path:
+                self._write_texture_to_xml(gloss_path, 'Glossmap')
+            elif not gloss_path and not vehicle_shader:
+                self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
 
         if vehicle_shader:
             if "Texture" not in self.xml_elements:

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -58,11 +58,14 @@ class MergeChildrenRoot(ShapeNode):
         apply_child_transforms = root_obj.i3d_merge_children.apply_transforms
         root_world_matrix = root_obj.matrix_world
         interpolation_steps = root_obj.i3d_merge_children.interpolation_steps
+        child_objects = sort_blender_objects_by_outliner_ordering(root_obj.children)
+        if root_obj.i3d_merge_children.reverse_order:
+            child_objects.reverse()
 
         self.logger.debug(f"Merging child meshes (Interpolation steps: {interpolation_steps})")
 
         g_value_index = 0
-        for child in sort_blender_objects_by_outliner_ordering(root_obj.children):
+        for child in child_objects:
             # Both mesh and non-mesh objects are processed; non-mesh objects only affect interpolation steps.
             # Generic value for this child and its descendants.
             generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX

--- a/addon/i3dio/node_classes/merge_children.py
+++ b/addon/i3dio/node_classes/merge_children.py
@@ -1,9 +1,10 @@
-import mathutils
 import bpy
+import mathutils
 
-from .node import SceneGraphNode
-from .shape import (ShapeNode, EvaluatedMesh)
 from ..i3d import I3D
+from ..utility import sort_blender_objects_by_outliner_ordering
+from .node import SceneGraphNode
+from .shape import EvaluatedMesh, ShapeNode
 
 # Maximum index value for `mergeChildren` objects, used to normalize
 # generic values (g_value) for shaders. This constant is critical for:
@@ -61,7 +62,7 @@ class MergeChildrenRoot(ShapeNode):
         self.logger.debug(f"Merging child meshes (Interpolation steps: {interpolation_steps})")
 
         g_value_index = 0
-        for child in root_obj.children:
+        for child in sort_blender_objects_by_outliner_ordering(root_obj.children):
             # Both mesh and non-mesh objects are processed; non-mesh objects only affect interpolation steps.
             # Generic value for this child and its descendants.
             generic_value = g_value_index / MERGE_CHILDREN_MAX_INDEX

--- a/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Small.py
+++ b/addon/i3dio/presets/i3dio/object/mesh/NonPhysics-Decals-Small.py
@@ -1,8 +1,9 @@
 import bpy
+
 obj = bpy.context.object
 
 obj.i3d_attributes.visibility = True
-obj.i3d_attributes.clip_distance = 300
+obj.i3d_attributes.clip_distance = 30
 obj.i3d_attributes.rigid_body_type = 'none'
 obj.data.i3d_attributes.casts_shadows = True
 obj.data.i3d_attributes.receive_shadows = True

--- a/addon/i3dio/ui/addon_preferences.py
+++ b/addon/i3dio/ui/addon_preferences.py
@@ -224,6 +224,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         return bpy.app.online_access
 
     def execute(self, context):
+        import html as _html
         import re
         from io import BytesIO
         from shutil import copyfileobj
@@ -231,12 +232,6 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
         from urllib.request import Request, urlopen
         from zipfile import BadZipFile, ZipFile
 
-        pattern_exporter = re.compile(
-            r'href="download\.php\?downloadId=(\d+)"[^>]*>\s*'
-            r'Blender Exporter Plugins v(\d+\.\d+\.\d+)\s*'
-            r'\(([^)]+)\)',
-            flags=re.IGNORECASE,
-        )
         ua = {"User-Agent": "Blender I3D IO Addon"}
 
         def _parse_version(version_str: str) -> tuple[int, int, int]:
@@ -246,19 +241,66 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
                 # If parsing fails, treat as 0.0.0 so valid versions win
                 return (0, 0, 0)
 
-        def _latest_exporter(html: str) -> tuple[str, str, str]:
-            matches = [m.groups() for m in pattern_exporter.finditer(html)]
-            if not matches:
-                raise ValueError("No exporter matches found")
-            fs = [m for m in matches if m[2].lower().startswith("farming simulator")]
-            candidates = fs or matches
-            return max(candidates, key=lambda t: _parse_version(t[1]))
+        _re_exporter_table = re.compile(
+            r"<h2>\s*Exporter\s*</h2>\s*(<table.*?</table>)",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        _re_tr = re.compile(r"<tr[^>]*>(.*?)</tr>", flags=re.IGNORECASE | re.DOTALL)
+        _re_td = re.compile(r"<t[dh][^>]*>(.*?)</t[dh]>", flags=re.IGNORECASE | re.DOTALL)
+        _re_download_id = re.compile(r'href="download\.php\?downloadId=(\d+)"', flags=re.IGNORECASE)
+        _re_version_in_name = re.compile(r"\bv(\d+\.\d+\.\d+)\b", flags=re.IGNORECASE)
+
+        def _strip_tags(s: str) -> str:
+            return _html.unescape(re.sub(r"<[^>]+>", "", s).strip())
+
+        def _latest_blender_exporter(html: str) -> tuple[str, str, str]:
+            """Returns: (download_id, exporter_version, compatibility) Prefers FS* rows over PMR rows."""
+            m = _re_exporter_table.search(html)
+            if not m:
+                raise ValueError("Exporter table not found (page layout changed?)")
+
+            table_html = m.group(1)
+            rows = _re_tr.findall(table_html)
+
+            found: list[tuple[str, str, str]] = []  # (download_id, version, compatibility)
+            for row_html in rows:
+                dm = _re_download_id.search(row_html)
+                if not dm:
+                    continue
+
+                cells = [_strip_tags(c) for c in _re_td.findall(row_html)]
+                if len(cells) < 2:
+                    continue
+
+                product_name = cells[0]
+                compatibility = cells[1]
+
+                if not product_name.lower().startswith("blender exporter plugins"):
+                    continue
+
+                vm = _re_version_in_name.search(product_name)
+                if not vm:
+                    continue
+
+                download_id = dm.group(1)
+                version = vm.group(1)
+                found.append((download_id, version, compatibility))
+
+            if not found:
+                raise ValueError("No Blender Exporter rows found")
+
+            # Only keep FS25 entries
+            fs25 = [t for t in found if t[2].strip().upper().startswith("FS25") or "FS25" in t[2].strip().upper()]
+            if not fs25:
+                raise ValueError("No FS25 Blender Exporter entry found on GDN downloads page")
+
+            return max(fs25, key=lambda t: _parse_version(t[1]))
 
         try:
             req = Request("https://gdn.giants-software.com/downloads.php", headers=ua)
             with urlopen(req, timeout=10.0) as resp:
-                html = resp.read().decode("utf-8", errors="replace")
-            download_id, exporter_version, game_name = _latest_exporter(html)
+                page_html = resp.read().decode("utf-8", errors="replace")
+            download_id, exporter_version, compatibility = _latest_blender_exporter(page_html)
 
             zip_url = f"https://gdn.giants-software.com/download.php?downloadId={download_id}"
             req = Request(zip_url, headers=ua)
@@ -286,7 +328,7 @@ class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
             return {'CANCELLED'}
 
         context.preferences.addons[base_package].preferences.i3d_converter_path = str(binary_path)
-        self.report({'INFO'}, f"Installed I3D Converter (v{exporter_version}, {game_name}).")
+        self.report({"INFO"}, f"Installed I3D Converter (Exporter v{exporter_version}, {compatibility}).")
         return {'FINISHED'}
 
 

--- a/addon/i3dio/ui/addon_preferences.py
+++ b/addon/i3dio/ui/addon_preferences.py
@@ -1,15 +1,16 @@
-import addon_utils
 import pathlib
 
+import addon_utils
 import bpy
+from bpy.props import EnumProperty, StringProperty
 from bpy.types import AddonPreferences
-from bpy.props import (StringProperty, EnumProperty)
+
 from .. import __package__ as base_package
 from ..utility import ext_user_dir
-from .shader_parser import populate_game_shaders
-from .material_templates import parse_templates
-from .collision_data import populate_collision_cache
 from .bit_mask_editor import get_bitmask_flags
+from .collision_data import populate_collision_cache
+from .material_templates import parse_templates
+from .shader_parser import populate_game_shaders
 
 
 class I3D_IO_AddonPreferences(AddonPreferences):
@@ -74,7 +75,7 @@ class I3D_IO_AddonPreferences(AddonPreferences):
 
         col.separator(factor=1.5)
         box = col.box()
-        box.label(text="Binary I3D Converter:")
+        box.label(text="I3D Converter (i3dConverter.exe):")
 
         giants_exist = any(addon.bl_info.get("name") == "GIANTS I3D Exporter Tools" for addon in addon_utils.modules())
         path = pathlib.Path(self.i3d_converter_path)
@@ -89,28 +90,31 @@ class I3D_IO_AddonPreferences(AddonPreferences):
             info_box.row().prop(self, "converter_mode_tabs", expand=True)
             if self.converter_mode_tabs == "AUTOMATIC":
                 if giants_exist:
-                    info_box.label(text="GIANTS I3D Exporter is installed.", icon="TRIA_RIGHT")
-                    info_box.label(text="Click below to set the path automatically:")
+                    info_box.label(text="GIANTS I3D Exporter add-on detected.", icon="CHECKMARK")
+                    info_box.label(text="Use its bundled i3dConverter.exe path:")
                     row = info_box.row()
-                    row.operator('i3dio.i3d_converter_path_from_giants_addon',
-                                 text="Get Path from GIANTS Addon", icon="FILE_ALIAS")
+                    row.operator(
+                        'i3dio.i3d_converter_path_from_giants_addon',
+                        text="Use Path from GIANTS Add-on",
+                        icon="FILE_ALIAS",
+                    )
                     info_box.separator()
-                info_box.label(text="Automatically download and set up the I3D Converter (GDN login required):",
-                               icon="TRIA_RIGHT")
+                info_box.label(text="Automatically download and set up the I3D Converter:", icon="TRIA_RIGHT")
+                info_box.label(text="Note: Blender may appear frozen during download (~18MB).", icon="INFO")
                 row = info_box.row()
-                row.operator("i3dio.download_i3d_converter",
-                             text="Download I3D Converter (GDN Login)...", icon='INTERNET')
+                row.operator("i3dio.download_i3d_converter", text="Download / Update from GDN...", icon='INTERNET')
             else:
                 info_box.label(text="Manually download and set up the I3D Converter:", icon="TRIA_RIGHT")
-                info_box.label(text="1. Download the GIANTS I3D Exporter addon:")
+                info_box.label(text="1. Open the GDN downloads page:")
                 row = info_box.row()
                 props = row.operator("wm.url_open", text="gdn.giants-software.com", icon='URL')
                 props.url = "https://gdn.giants-software.com/downloads.php"
 
-                info_box.label(text="2. Extract the .zip file.")
-                info_box.label(text="3. Locate io_export_i3d/util/i3dConverter.exe.")
-                info_box.label(text="4. Move it to a convenient location.")
-                info_box.label(text="5. Use the file browser icon below to set the path manually.")
+                info_box.label(text="2. Download the GIANTS Blender Exporter .zip for your FS version.")
+                info_box.label(text="3. Extract the .zip file.")
+                info_box.label(text="4. Locate io_export_i3d/util/i3dConverter.exe.")
+                info_box.label(text="5. Move it to a convenient location.")
+                info_box.label(text="6. Use the file browser below to set the path manually.")
         row = box.row(align=True)
         row.use_property_split = True
         row.prop(self, 'i3d_converter_path', placeholder="Path to i3dConverter.exe")
@@ -165,14 +169,15 @@ class I3D_IO_OT_reset_i3d_converter_path(bpy.types.Operator):
 
 class I3D_IO_OT_i3d_converter_path_from_giants_addon(bpy.types.Operator):
     bl_idname = "i3dio.i3d_converter_path_from_giants_addon"
-    bl_label = "Get I3D converter path from Giants addon"
-    bl_description = "Get the i3d converter path from the Giants exporter addon"
+    bl_label = "Get I3D converter path from Giants Add-on"
+    bl_description = "Copy i3dConverter.exe from the GIANTS exporter add-on into the add-on bin folder"
     bl_options = {'INTERNAL'}
 
     MIN_VERSION = (10, 0, 0)
     ADDON_NAME = "GIANTS I3D Exporter Tools"
 
     def execute(self, context):
+        import shutil
         latest = None
         for addon in addon_utils.modules():
             info = getattr(addon, "bl_info", {})
@@ -182,111 +187,107 @@ class I3D_IO_OT_i3d_converter_path_from_giants_addon(bpy.types.Operator):
                     if not latest or version > latest[0]:
                         latest = (version, addon)
         if not latest:
-            self.report({"WARNING"}, "No GIANTS I3D Exporter Tools v10+ addon found.")
-            return {"CANCELLED"}
-        addon = latest[1]
-        path = pathlib.Path(addon.__file__).parent.joinpath('util/i3dConverter.exe')
-        if not path.exists():
-            self.report({"WARNING"}, f"Converter not found at: {path}")
-            return {"CANCELLED"}
+            self.report({'WARNING'}, "No GIANTS I3D Exporter Tools v10+ addon found.")
+            return {'CANCELLED'}
+        version, addon = latest
+        src = pathlib.Path(addon.__file__).parent / "util" / "i3dConverter.exe"
+        if not src.exists():
+            self.report({'WARNING'}, f"Converter not found at: {src}")
+            return {'CANCELLED'}
+        dst = ext_user_dir("bin") / "i3dConverter.exe"
+        try:
+            shutil.copyfile(src, dst)
+        except OSError as e:
+            self.report({'WARNING'}, f"Failed to copy converter: {e}")
+            return {'CANCELLED'}
 
-        context.preferences.addons[base_package].preferences.i3d_converter_path = str(path)
-        self.report({"INFO"}, f"Found converter from version {latest[0]} at: {path}")
-        return {"FINISHED"}
+        context.preferences.addons[base_package].preferences.i3d_converter_path = str(dst)
+        self.report({'INFO'}, f"Imported I3D Converter from GIANTS exporter v{version}")
+        return {'FINISHED'}
 
 
 class I3D_IO_OT_download_i3d_converter(bpy.types.Operator):
     bl_idname = "i3dio.download_i3d_converter"
-    bl_label = "Download I3D Converter (GDN Login Required)"
+    bl_label = "Download I3D Converter"
     bl_description = (
-        "Download from Giants Developer Network. "
-        "Requires a registered account at https://gdn.giants-software.com/."
+        "Download i3dConverter.exe from the Giants Developer Network.\nRequires online access.\n"
+        "Note: Blender may appear frozen during download."
     )
     bl_options = {'INTERNAL'}
 
-    email: StringProperty(name="GDN Email", default="")
-    password: StringProperty(name="GDN Password", default="", subtype="PASSWORD")
-
     @classmethod
     def poll(cls, context):
-        cls.poll_message_set("Online access required to download the I3D Converter, "
-                             "enable it in the Blender System Preferences to use this feature!")
+        cls.poll_message_set(
+            "Online access required to download the I3D Converter, "
+            "enable it in the Blender System Preferences to use this feature!"
+        )
         return bpy.app.online_access
 
     def execute(self, context):
         import re
         from io import BytesIO
-        from requests import Session
-        from zipfile import (ZipFile, BadZipfile)
         from shutil import copyfileobj
+        from urllib.error import HTTPError, URLError
+        from urllib.request import Request, urlopen
+        from zipfile import BadZipFile, ZipFile
 
-        # Attempt to login using provided credentials
-        session = Session()
-        request = session.post('https://gdn.giants-software.com/index.php',
-                               data={'greenstoneX': '1', 'redstoneX': self.email, 'bluestoneX': self.password})
-
-        # Clear email and password after usage
-        self.email = ""
-        self.password = ""
-
-        # Check if login was successful
-        if not re.search(r'href="index\.php\?logout=true"', request.text):
-            self.report({'WARNING'}, "Could not log in to Giants Developer Network (GDN). "
-                        "Make sure you enter your account email and password from https://gdn.giants-software.com/")
-            return {'CANCELLED'}
-
-        # Get download page
-        request = session.get('https://gdn.giants-software.com/downloads.php')
-
-        # Find the download IDs for the all Giants Blender Exporters (As long as Giants names them the same way)
-        result = re.findall(
-            r'href="download.php\?downloadId=([0-9]+)">Blender Exporter Plugins v([0-9]+.[0-9]+.[0-9]+)',
-            request.text
+        pattern_exporter = re.compile(
+            r'href="download\.php\?downloadId=(\d+)"[^>]*>\s*'
+            r'Blender Exporter Plugins v(\d+\.\d+\.\d+)\s*'
+            r'\(([^)]+)\)',
+            flags=re.IGNORECASE,
         )
+        ua = {"User-Agent": "Blender I3D IO Addon"}
 
-        # Assume the first found is the newest
-        download_id, exporter_version = result[0]
+        def _parse_version(version_str: str) -> tuple[int, int, int]:
+            try:
+                return tuple((int(p) for p in version_str.split(".")))
+            except Exception:
+                # If parsing fails, treat as 0.0.0 so valid versions win
+                return (0, 0, 0)
 
-        # Request download of Giants I3D Exporter
-        download_url = f'https://gdn.giants-software.com/download.php?downloadId={download_id}'
-        request = session.get(download_url)
+        def _latest_exporter(html: str) -> tuple[str, str, str]:
+            matches = [m.groups() for m in pattern_exporter.finditer(html)]
+            if not matches:
+                raise ValueError("No exporter matches found")
+            fs = [m for m in matches if m[2].lower().startswith("farming simulator")]
+            candidates = fs or matches
+            return max(candidates, key=lambda t: _parse_version(t[1]))
 
         try:
-            # Create in-memory zipfile from downloaded content
-            zipfile = ZipFile(BytesIO(request.content), 'r')
-            # Write under the per-extension user dir
-            binary_path = ext_user_dir("bin") / 'i3dConverter.exe'
+            req = Request("https://gdn.giants-software.com/downloads.php", headers=ua)
+            with urlopen(req, timeout=10.0) as resp:
+                html = resp.read().decode("utf-8", errors="replace")
+            download_id, exporter_version, game_name = _latest_exporter(html)
 
-            # Extract I3D Converter Binary from zipfile and save to disk
-            with zipfile.open('io_export_i3d/util/i3dConverter.exe') as binary_zip, open(binary_path, 'wb') as saved:
-                copyfileobj(binary_zip, saved)
-            # Set I3D Converter Binary path to newly downloaded converter
-            context.preferences.addons[base_package].preferences.i3d_converter_path = str(binary_path)
-        except (BadZipfile, KeyError, OSError) as e:
-            self.report({'WARNING'}, f"Failed to fetch/install the GIANTS I3D Converter: {e}")
+            zip_url = f"https://gdn.giants-software.com/download.php?downloadId={download_id}"
+            req = Request(zip_url, headers=ua)
+            with urlopen(req, timeout=20.0) as resp:
+                zip_data = resp.read()
+
+            with ZipFile(BytesIO(zip_data), 'r') as zf:
+                exe_member = next((n for n in zf.namelist() if n.lower().endswith("i3dconverter.exe")), None)
+                if not exe_member:
+                    raise KeyError("i3dConverter.exe not found in ZIP archive")
+                binary_path = ext_user_dir("bin") / "i3dConverter.exe"
+                with zf.open(exe_member) as binary_zip, open(binary_path, "wb") as saved:
+                    copyfileobj(binary_zip, saved)
+        except HTTPError as e:
+            self.report({'WARNING'}, f"GDN returned HTTP error {e.code}.")
+            return {'CANCELLED'}
+        except URLError as e:
+            self.report({'WARNING'}, f"Failed to reach GDN downloads page: {e.reason}.")
+            return {'CANCELLED'}
+        except (BadZipFile, KeyError, OSError, ValueError) as e:
+            self.report({'WARNING'}, f"Failed to install i3dConverter.exe: {e}")
+            return {'CANCELLED'}
+        except Exception as e:
+            self.report({'WARNING'}, f"Unexpected error while fetching exporter list: {e}")
             return {'CANCELLED'}
 
-        self.report({'INFO'}, f"Installed i3dConverter.exe (Exporter v{exporter_version}) to {binary_path}")
+        context.preferences.addons[base_package].preferences.i3d_converter_path = str(binary_path)
+        self.report({'INFO'}, f"Installed I3D Converter (v{exporter_version}, {game_name}).")
         return {'FINISHED'}
-
-    def invoke(self, context, event):
-        bin_path = ext_user_dir("bin") / 'i3dConverter.exe'
-        if bin_path.exists():
-            context.preferences.addons[base_package].preferences.i3d_converter_path = str(bin_path)
-            self.report({"INFO"}, f"Existing i3dConverter.exe found at: {bin_path}")
-            return {'FINISHED'}
-        return context.window_manager.invoke_props_dialog(self, width=360)
-
-    def draw(self, _context):
-        layout = self.layout
-        box = layout.box()
-        box.label(text="Enter your GDN (Giants Developer Network) login details:", icon='INFO')
-        box.label(text="You need a free account at https://gdn.giants-software.com/")
-        box.prop(self, "email")
-        box.prop(self, "password")
-        row = box.row()
-        row.alignment = "CENTER"
-        row.label(text="Blender UI will appear frozen during file download (~15MB) ", icon="ERROR")
 
 
 classes = (

--- a/addon/i3dio/ui/material_templates.py
+++ b/addon/i3dio/ui/material_templates.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
-from dataclasses import dataclass, fields, field
+
+from dataclasses import dataclass, field, fields
 from pathlib import Path
+
 import bpy
+import bpy.utils.previews
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper
 
 from .. import xml_i3d

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -636,7 +636,9 @@ class I3D_IO_OT_set_collision_preset(bpy.types.Operator):
     bl_idname = 'i3dio.set_collision_preset'
     bl_label = 'Set Collision Preset'
     bl_options = {'INTERNAL', 'UNDO'}
+
     preset: StringProperty()
+    apply_to_selected: BoolProperty(options={'SKIP_SAVE'})
 
     @classmethod
     def description(cls, _context, properties):
@@ -644,9 +646,19 @@ class I3D_IO_OT_set_collision_preset(bpy.types.Operator):
         if desc and getattr(desc, 'desc', None):
             return desc.desc
         return f"Set the collision preset to {properties.preset}"
-
+    
+    def invoke(self, context, event):
+        self.apply_to_selected = event.alt
+        return self.execute(context)
+    
     def execute(self, context):
-        context.object.i3d_attributes.collision_preset_name = self.preset
+        if self.apply_to_selected:
+            for obj in context.selected_objects:
+                if not obj.type == 'MESH':
+                    continue
+                obj.i3d_attributes.collision_preset_name = self.preset
+        else:
+            context.object.i3d_attributes.collision_preset_name = self.preset
         return {'FINISHED'}
 
 

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -518,6 +518,15 @@ class I3DMergeChildren(bpy.types.PropertyGroup):
         min=1,
         max=10
     )
+    reverse_order: bpy.props.BoolProperty(
+        name="Reverse Order",
+        description=(
+            "If enabled, child objects are processed in reverse order based on their appearance in the outliner. "
+            "This affects the assignment of generic values used in shaders, "
+            "which can influence rendering order or animation sequences."
+        ),
+        default=False
+    )
 
 
 @register
@@ -963,6 +972,7 @@ def draw_merge_children_attributes(layout: bpy.types.UILayout, i3d_merge_childre
         panel.enabled = i3d_merge_children.enabled
         panel.prop(i3d_merge_children, 'apply_transforms')
         panel.prop(i3d_merge_children, 'interpolation_steps')
+        panel.prop(i3d_merge_children, 'reverse_order')
 
 
 def draw_motion_path_array_attrs(layout: bpy.types.UILayout, i3d_motion_path_array: bpy.types.PropertyGroup) -> None:

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -213,6 +213,27 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         default=""
     )
 
+    i3d_diffuse_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Diffuse Map",
+        description="Manual Diffuse/Base Color texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_gloss_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Gloss Map",
+        description="Manual Gloss/Specular texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_normal_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Normal Map",
+        description="Manual Normal Map texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_emissive_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Emissive Map",
+        description="Manual Emissive texture override for i3D export. Overrides shader node detection"
+    )
+
     i3d_map = {
         'alpha_blending': {'name': 'alphaBlending', 'default': False},
         'shading_rate': {'name': 'shadingRate', 'default': '1x1'},
@@ -331,6 +352,14 @@ class I3D_IO_PT_material_shader(Panel):
         row = box.row()
         row.enabled = material.i3d_attributes.use_material_slot_name
         row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name", placeholder=material.name)
+
+        box = layout.box()
+        box.label(text="Base Textures", icon='IMAGE_DATA')
+        col = box.column(align=True)
+        col.prop(i3d_attributes, 'i3d_diffuse_map')
+        col.prop(i3d_attributes, 'i3d_gloss_map')
+        col.prop(i3d_attributes, 'i3d_normal_map')
+        col.prop(i3d_attributes, 'i3d_emissive_map')
 
         layout.separator(type='LINE')
 

--- a/addon/i3dio/ui/udim_picker.py
+++ b/addon/i3dio/ui/udim_picker.py
@@ -23,6 +23,28 @@ def register(cls):
     return cls
 
 
+def uv_loop_selected(bm, loop, loop_uv, face, *, sync_enabled: bool) -> bool:
+    """Returns True if this UV loop should be considered selected, supporting both Blender 4.x and 5.0+."""
+    # Sync enabled = mesh selection drives UV selection
+    if sync_enabled:
+        return loop.vert.select and face.select
+    # When sync is disabled, UV selection drives it (if available), else fallback to mesh selection
+    # Blender 5.0+
+    if hasattr(loop, "uv_select_vert"):
+        # Ensure selection state is valid
+        if hasattr(bm, "uv_select_sync_valid") and not bm.uv_select_sync_valid:
+            bm.uv_select_sync_from_mesh()
+        if loop.uv_select_vert or loop.uv_select_edge or face.uv_select:
+            return True
+        # No UV selection, fall back to mesh selection
+        return loop.vert.select and face.select
+    # Fallback for Blender 4.x, where selection lives on the UV loop
+    if getattr(loop_uv, "select", False):
+        return True
+    # No UV selection, fall back to mesh selection
+    return loop.vert.select and face.select
+
+
 @register
 class I3D_IO_OT_udim_mover(Operator):
     bl_idname = "i3dio.udim_mover"
@@ -39,35 +61,42 @@ class I3D_IO_OT_udim_mover(Operator):
         return obj and obj.type == "MESH" and obj.mode == "EDIT"
 
     def execute(self, context):
-        # Grab the current sync setting, instead of looking it up all the time
-        sync_enabled = bpy.context.scene.tool_settings.use_uv_select_sync
+        sync_enabled = context.scene.tool_settings.use_uv_select_sync
         if not sync_enabled and "UV Editing" not in [screen.name for screen in context.workspace.screens]:
             self.report({"INFO"}, "UDIM Picker was used within mesh editor, but UV sync is disabled!")
             # Technically I could return the operator, but I will allow it to run just in case someone has some
             # other way of selecting uv's outside of the uv-editor screen
 
-        # Grabs only unique meshes (no instances) and weeds out any objects without selected vertices
-        objects = [obj for obj in bpy.context.objects_in_mode_unique_data if obj.data.total_vert_sel]
+        # If sync is OFF, user may have UV-only selection, so don't filter by total_vert_sel
+        if sync_enabled:
+            objects = [obj for obj in context.objects_in_mode_unique_data if obj.data.total_vert_sel]
+        else:
+            objects = list(context.objects_in_mode_unique_data)
+
         for obj in objects:
             bm = bmesh.from_edit_mesh(obj.data)
             uv_layer = bm.loops.layers.uv.verify()
+
+            # If sync is enabled, restrict to selected faces only
+            # else UV selection may exist without face.select, so iterate all faces
+            faces_iter = [f for f in bm.faces if f.select] if sync_enabled else bm.faces
+
             if self.mode == "RELATIVE":
-                for face in [face for face in bm.faces if face.select]:
+                for face in faces_iter:
                     for loop in face.loops:
                         loop_uv = loop[uv_layer]
-                        # If sync is enabled, loop_uv.select isn't set on selection
-                        if loop.vert.select and (sync_enabled or loop_uv.select):
+                        if uv_loop_selected(bm, loop, loop_uv, face, sync_enabled=sync_enabled):
                             loop_uv.uv += Vector(self.uv_offset)
+
             elif self.mode == "ABSOLUTE":
                 # Could use a bidict for this, if I want to install the extra dependency
                 faces_to_verts = defaultdict(set)
                 verts_to_faces = defaultdict(set)
-                for face in [face for face in bm.faces if face.select]:
-                    # print(f"Face {face.index}")
+                for face in faces_iter:
                     # Calculate lists of unique vert uv's and make a reverse lookup between faces and verts
                     for loop in face.loops:
                         loop_uv = loop[uv_layer]
-                        if loop.vert.select and (sync_enabled or loop_uv.select):
+                        if uv_loop_selected(bm, loop, loop_uv, face, sync_enabled=sync_enabled):
                             unique_uv_id = loop_uv.uv.to_tuple(5), loop.vert.index
                             faces_to_verts[face.index].add(unique_uv_id)
                             verts_to_faces[unique_uv_id].add(face.index)
@@ -89,7 +118,7 @@ class I3D_IO_OT_udim_mover(Operator):
                     for face in island:
                         for loop in face.loops:
                             loop_uv = loop[uv_layer]
-                            if loop.vert.select and (sync_enabled or loop_uv.select):
+                            if uv_loop_selected(bm, loop, loop_uv, face, sync_enabled=sync_enabled):
                                 uvs_to_move.append(loop_uv)
                                 cumulative_uv_position += loop_uv.uv
 


### PR DESCRIPTION
Adds a selection for base textures in the Material Properties tab. If textures are selected here, they will be used preferentially instead of being read from the shading nodes. This resolves the issue when textures are not directly connected to the shader but are instead distributed across multiple nodes.