### PR TITLE
feat: manual base texture selection before read textures from shading nodes

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -45,52 +45,84 @@ class Material(Node):
             return self.i3d_attrs.material_slot_name or self.blender_material.name
         return None
 
+    @staticmethod
+    def _path_from_blender_image(image: 'bpy.types.Image | None') -> str | None:
+        """Get filepath from a direct bpy.types.Image reference (used by manual override PointerProperties)."""
+        if not image:
+            return None
+        return image.filepath_from_user() or (image.filepath if image.filepath else None)
+
     def populate_xml_element(self) -> None:
         vehicle_shader = (self.i3d_attrs.shader_name == "vehicleShader")
+
+        # Manual texture overrides take priority over shader node detection.
+        # If a PointerProperty is set, that image is used and node detection is skipped for that slot.
+        override_diffuse  = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_diffuse_map',  None))
+        override_gloss    = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_gloss_map',    None))
+        override_normal   = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_normal_map',   None))
+        override_emissive = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_emissive_map', None))
+
         principled = PrincipledBSDFWrapper(self.blender_material, is_readonly=True)
         bsdf = principled.node_principled_bsdf
 
-        emission_tex_path = self._image_path(principled.emission_color_texture)
+        # EMISSIVE
         skip_diffuse = False
-        if emission_tex_path:
-            self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
+        if override_emissive:
+            self._write_texture_to_xml(override_emissive, 'Emissivemap')
             skip_diffuse = True
-        elif principled.emission_strength > 0:
-            emis_color = (
-                self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
-            )
-            self._write_color(emis_color, 'emissiveColor')
-            skip_diffuse = True
-
-        if not skip_diffuse:
-            base_tex_path = self._image_path(principled.base_color_texture)
-            if base_tex_path:
-                self._write_texture_to_xml(base_tex_path, 'Texture')
-            else:
-                base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
-                self._write_color(base_col, 'diffuseColor')
-
-        normalmap_tex_path = self._image_path(principled.normalmap_texture)
-        if normalmap_tex_path:
-            bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
-            self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
-
-        gloss_path = None
-        if glossnode := self._find_node_by_name('glossmap'):
-            match glossnode.bl_idname:
-                case "ShaderNodeTexImage":
-                    gloss_path = self._image_path(glossnode)
-                case "ShaderNodeSeparateColor":
-                    input = glossnode.inputs['Color']
-                    if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
-                        gloss_path = self._image_path(source)
         else:
-            gloss_path = self._image_path(principled.specular_texture)
+            emission_tex_path = self._image_path(principled.emission_color_texture)
+            if emission_tex_path:
+                self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
+                skip_diffuse = True
+            elif principled.emission_strength > 0:
+                emis_color = (
+                    self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
+                )
+                self._write_color(emis_color, 'emissiveColor')
+                skip_diffuse = True
 
-        if gloss_path:
-            self._write_texture_to_xml(gloss_path, 'Glossmap')
-        elif not gloss_path and not vehicle_shader:
-            self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
+        # DIFFUSE
+        if not skip_diffuse:
+            if override_diffuse:
+                self._write_texture_to_xml(override_diffuse, 'Texture')
+            else:
+                base_tex_path = self._image_path(principled.base_color_texture)
+                if base_tex_path:
+                    self._write_texture_to_xml(base_tex_path, 'Texture')
+                else:
+                    base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
+                    self._write_color(base_col, 'diffuseColor')
+
+        # NORMAL MAP
+        if override_normal:
+            self._write_texture_to_xml(override_normal, 'Normalmap')
+        else:
+            normalmap_tex_path = self._image_path(principled.normalmap_texture)
+            if normalmap_tex_path:
+                bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
+                self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
+
+        # GLOSS MAP
+        if override_gloss:
+            self._write_texture_to_xml(override_gloss, 'Glossmap')
+        else:
+            gloss_path = None
+            if glossnode := self._find_node_by_name('glossmap'):
+                match glossnode.bl_idname:
+                    case "ShaderNodeTexImage":
+                        gloss_path = self._image_path(glossnode)
+                    case "ShaderNodeSeparateColor":
+                        input = glossnode.inputs['Color']
+                        if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
+                            gloss_path = self._image_path(source)
+            else:
+                gloss_path = self._image_path(principled.specular_texture)
+
+            if gloss_path:
+                self._write_texture_to_xml(gloss_path, 'Glossmap')
+            elif not gloss_path and not vehicle_shader:
+                self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
 
         if vehicle_shader:
             if "Texture" not in self.xml_elements:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -45,84 +45,52 @@ class Material(Node):
             return self.i3d_attrs.material_slot_name or self.blender_material.name
         return None
 
-    @staticmethod
-    def _path_from_blender_image(image: 'bpy.types.Image | None') -> str | None:
-        """Get filepath from a direct bpy.types.Image reference (used by manual override PointerProperties)."""
-        if not image:
-            return None
-        return image.filepath_from_user() or (image.filepath if image.filepath else None)
-
     def populate_xml_element(self) -> None:
         vehicle_shader = (self.i3d_attrs.shader_name == "vehicleShader")
-
-        # Manual texture overrides take priority over shader node detection.
-        # If a PointerProperty is set, that image is used and node detection is skipped for that slot.
-        override_diffuse  = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_diffuse_map',  None))
-        override_gloss    = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_gloss_map',    None))
-        override_normal   = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_normal_map',   None))
-        override_emissive = self._path_from_blender_image(getattr(self.i3d_attrs, 'i3d_emissive_map', None))
-
         principled = PrincipledBSDFWrapper(self.blender_material, is_readonly=True)
         bsdf = principled.node_principled_bsdf
 
-        # EMISSIVE
+        emission_tex_path = self._image_path(principled.emission_color_texture)
         skip_diffuse = False
-        if override_emissive:
-            self._write_texture_to_xml(override_emissive, 'Emissivemap')
+        if emission_tex_path:
+            self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
             skip_diffuse = True
-        else:
-            emission_tex_path = self._image_path(principled.emission_color_texture)
-            if emission_tex_path:
-                self._write_texture_to_xml(emission_tex_path, 'Emissivemap')
-                skip_diffuse = True
-            elif principled.emission_strength > 0:
-                emis_color = (
-                    self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
-                )
-                self._write_color(emis_color, 'emissiveColor')
-                skip_diffuse = True
+        elif principled.emission_strength > 0:
+            emis_color = (
+                self._linked_rgb_color(bsdf.inputs['Emission Color'] if bsdf else None) or principled.emission_color
+            )
+            self._write_color(emis_color, 'emissiveColor')
+            skip_diffuse = True
 
-        # DIFFUSE
         if not skip_diffuse:
-            if override_diffuse:
-                self._write_texture_to_xml(override_diffuse, 'Texture')
+            base_tex_path = self._image_path(principled.base_color_texture)
+            if base_tex_path:
+                self._write_texture_to_xml(base_tex_path, 'Texture')
             else:
-                base_tex_path = self._image_path(principled.base_color_texture)
-                if base_tex_path:
-                    self._write_texture_to_xml(base_tex_path, 'Texture')
-                else:
-                    base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
-                    self._write_color(base_col, 'diffuseColor')
+                base_col = self._linked_rgb_color(bsdf.inputs['Base Color'] if bsdf else None) or principled.base_color
+                self._write_color(base_col, 'diffuseColor')
 
-        # NORMAL MAP
-        if override_normal:
-            self._write_texture_to_xml(override_normal, 'Normalmap')
+        normalmap_tex_path = self._image_path(principled.normalmap_texture)
+        if normalmap_tex_path:
+            bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
+            self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
+
+        gloss_path = None
+        if glossnode := self._find_node_by_name('glossmap'):
+            match glossnode.bl_idname:
+                case "ShaderNodeTexImage":
+                    gloss_path = self._image_path(glossnode)
+                case "ShaderNodeSeparateColor":
+                    input = glossnode.inputs['Color']
+                    if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
+                        gloss_path = self._image_path(source)
         else:
-            normalmap_tex_path = self._image_path(principled.normalmap_texture)
-            if normalmap_tex_path:
-                bump_depth = principled.normalmap_strength if principled.normalmap_strength != 1.0 else None
-                self._write_texture_to_xml(normalmap_tex_path, 'Normalmap', bump_depth)
+            gloss_path = self._image_path(principled.specular_texture)
 
-        # GLOSS MAP
-        if override_gloss:
-            self._write_texture_to_xml(override_gloss, 'Glossmap')
-        else:
-            gloss_path = None
-            if glossnode := self._find_node_by_name('glossmap'):
-                match glossnode.bl_idname:
-                    case "ShaderNodeTexImage":
-                        gloss_path = self._image_path(glossnode)
-                    case "ShaderNodeSeparateColor":
-                        input = glossnode.inputs['Color']
-                        if input.is_linked and (source := input.links[0].from_node).bl_idname == "ShaderNodeTexImage":
-                            gloss_path = self._image_path(source)
-            else:
-                gloss_path = self._image_path(principled.specular_texture)
-
-            if gloss_path:
-                self._write_texture_to_xml(gloss_path, 'Glossmap')
-            elif not gloss_path and not vehicle_shader:
-                self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
+        if gloss_path:
+            self._write_texture_to_xml(gloss_path, 'Glossmap')
+        elif not gloss_path and not vehicle_shader:
+            self._write_color([1.0 - principled.roughness, principled.specular, principled.metallic], 'specularColor')
 
         if vehicle_shader:
             if "Texture" not in self.xml_elements:

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -213,6 +213,27 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         default=""
     )
 
+    i3d_diffuse_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Diffuse Map",
+        description="Manual Diffuse/Base Color texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_gloss_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Gloss Map",
+        description="Manual Gloss/Specular texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_normal_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Normal Map",
+        description="Manual Normal Map texture override for i3D export. Overrides shader node detection"
+    )
+    i3d_emissive_map: PointerProperty(
+        type=bpy.types.Image,
+        name="Emissive Map",
+        description="Manual Emissive texture override for i3D export. Overrides shader node detection"
+    )
+
     i3d_map = {
         'alpha_blending': {'name': 'alphaBlending', 'default': False},
         'shading_rate': {'name': 'shadingRate', 'default': '1x1'},
@@ -331,6 +352,14 @@ class I3D_IO_PT_material_shader(Panel):
         row = box.row()
         row.enabled = material.i3d_attributes.use_material_slot_name
         row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name", placeholder=material.name)
+
+        box = layout.box()
+        box.label(text="Base Textures", icon='IMAGE_DATA')
+        col = box.column(align=True)
+        col.prop(i3d_attributes, 'i3d_diffuse_map')
+        col.prop(i3d_attributes, 'i3d_gloss_map')
+        col.prop(i3d_attributes, 'i3d_normal_map')
+        col.prop(i3d_attributes, 'i3d_emissive_map')
 
         layout.separator(type='LINE')
 

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -213,27 +213,6 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         default=""
     )
 
-    i3d_diffuse_map: PointerProperty(
-        type=bpy.types.Image,
-        name="Diffuse Map",
-        description="Manual Diffuse/Base Color texture override for i3D export. Overrides shader node detection"
-    )
-    i3d_gloss_map: PointerProperty(
-        type=bpy.types.Image,
-        name="Gloss Map",
-        description="Manual Gloss/Specular texture override for i3D export. Overrides shader node detection"
-    )
-    i3d_normal_map: PointerProperty(
-        type=bpy.types.Image,
-        name="Normal Map",
-        description="Manual Normal Map texture override for i3D export. Overrides shader node detection"
-    )
-    i3d_emissive_map: PointerProperty(
-        type=bpy.types.Image,
-        name="Emissive Map",
-        description="Manual Emissive texture override for i3D export. Overrides shader node detection"
-    )
-
     i3d_map = {
         'alpha_blending': {'name': 'alphaBlending', 'default': False},
         'shading_rate': {'name': 'shadingRate', 'default': '1x1'},
@@ -352,14 +331,6 @@ class I3D_IO_PT_material_shader(Panel):
         row = box.row()
         row.enabled = material.i3d_attributes.use_material_slot_name
         row.prop(material.i3d_attributes, 'material_slot_name', text="Custom Name", placeholder=material.name)
-
-        box = layout.box()
-        box.label(text="Base Textures", icon='IMAGE_DATA')
-        col = box.column(align=True)
-        col.prop(i3d_attributes, 'i3d_diffuse_map')
-        col.prop(i3d_attributes, 'i3d_gloss_map')
-        col.prop(i3d_attributes, 'i3d_normal_map')
-        col.prop(i3d_attributes, 'i3d_emissive_map')
 
         layout.separator(type='LINE')
 


### PR DESCRIPTION
Adds a selection for base textures in the Material Properties tab. If textures are selected here, they will be used preferentially instead of being read from the shading nodes. This resolves the issue when textures are not directly connected to the shader but are instead distributed across multiple nodes.