### PR TITLE
refactor(shader-parser): improve shader metadata parsing

### DIFF
--- a/addon/i3dio/ui/shader_parser.py
+++ b/addon/i3dio/ui/shader_parser.py
@@ -3,20 +3,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import bpy
-from bpy.app.handlers import (persistent, load_post)
+from bpy.app.handlers import persistent, load_post
 
 from .. import xml_i3d
+from ..debugging import addon_logger
 from ..utility import get_fs_data_path
 
 
-SHADERS_GAME: ShaderDict = {}
-SHADERS_CUSTOM: ShaderDict = {}
+logger = addon_logger.getChild("shader_parser")
 
 
 @dataclass
 class ShaderParameter:
     name: str
-    type: int
+    component_count: int
     default_value: list[float]
     min_value: float = -xml_i3d.i3d_max
     max_value: float = xml_i3d.i3d_max
@@ -45,69 +45,69 @@ class ShaderMetadata:
 ShaderDict = dict[str, ShaderMetadata]
 
 
+SHADERS_GAME: ShaderDict = {}
+SHADERS_CUSTOM: ShaderDict = {}
+
+
 def get_shader_dict(use_custom: bool = False) -> ShaderDict:
     return SHADERS_CUSTOM if use_custom else SHADERS_GAME
 
 
 def parse_shader_parameters(parameter: xml_i3d.XML_Element) -> list[ShaderParameter]:
-    """Parses a shader parameter element and returns a list of dictionaries with parameter data."""
-    parameter_list: list[ShaderParameter] = []
-
+    """Parses a shader parameter element and returns shader parameter data."""
     type_str = parameter.attrib.get('type', 'float4')
-    type_length = {'float': 1, 'float1': 1, 'float2': 2, 'float3': 3, 'float4': 4}.get(type_str, 4)
-
-    def _parse_floats(val: str | None, default: float = 0.0) -> list[float]:
-        if val is None:
-            return [default] * type_length
+    component_count = {'float': 1, 'float1': 1, 'float2': 2, 'float3': 3, 'float4': 4}.get(type_str, 4)
+    
+    def _parse_float_list(value: str | None, default: float = 0.0) -> list[float]:
+        if value is None:
+            return [default] * component_count
         try:
-            vals = [float(x) for x in val.split()]
-            # If too many, truncate; if too few, pad with default
-            return vals[:type_length] + [default] * (type_length - len(vals))
-        except Exception:
-            return [default] * type_length
+            values = [float(x) for x in value.split()]
+        except ValueError:
+            return [default] * component_count
+        # If too many, truncate; if too few, pad with default
+        return (values + [default] * component_count)[:component_count]
 
     param_name = parameter.attrib['name']
     template = parameter.attrib.get('template', 'default')
-    default_value = _parse_floats(parameter.attrib.get('defaultValue'))
-    min_str = parameter.attrib.get('minValue')
-    max_str = parameter.attrib.get('maxValue')
-    min_value = _parse_floats(min_str) if min_str else [min(-xml_i3d.i3d_max, min(default_value))] * type_length
-    max_value = _parse_floats(max_str) if max_str else [max(xml_i3d.i3d_max, max(default_value))] * type_length
-    # Blender supports only a single min/max per prop, so if all are the same, use that; else fallback to i3d_max
-    min_single = min_value[0] if all(x == min_value[0] for x in min_value) else -xml_i3d.i3d_max
-    max_single = max_value[0] if all(x == max_value[0] for x in max_value) else xml_i3d.i3d_max
-
     description = parameter.attrib.get("description", "").replace("\\n", "\n")
-    if parameter.attrib.get('arraySize') is not None:
-        for child in parameter:
-            child_default = _parse_floats(child.text)
-            parameter_list.append(ShaderParameter(
-                name=f"{param_name}{child.attrib.get('index', '')}",
-                type=type_length,
-                default_value=child_default,
-                min_value=min_single,
-                max_value=max_single,
-                description=description,
-                template=template
-            ))
-    else:
-        parameter_list.append(ShaderParameter(
-            name=param_name,
-            type=type_length,
-            default_value=default_value,
+
+    default_value = _parse_float_list(parameter.attrib.get('defaultValue'))
+    min_values = _parse_float_list(parameter.attrib.get('minValue'), min(-xml_i3d.i3d_max, min(default_value)))
+    max_values = _parse_float_list(parameter.attrib.get('maxValue'), max(xml_i3d.i3d_max, max(default_value)))
+    # Blender supports only a single min/max per prop, so if all are the same, use that; else fallback to i3d_max
+    min_single = min_values[0] if all(x == min_values[0] for x in min_values) else -xml_i3d.i3d_max
+    max_single = max_values[0] if all(x == max_values[0] for x in max_values) else xml_i3d.i3d_max
+
+    def make_parameter(name: str, value: list[float]) -> ShaderParameter:
+        return ShaderParameter(
+            name=name,
+            component_count=component_count,
+            default_value=value,
             min_value=min_single,
             max_value=max_single,
             description=description,
             template=template
-        ))
+        )
 
-    return parameter_list
+    if parameter.attrib.get('arraySize') is None:
+        return [make_parameter(param_name, default_value)]
+    return [
+        make_parameter(
+            name=f"{param_name}{child.attrib.get('index', i)}",
+            value=_parse_float_list(child.text),
+        )
+        for i, child in enumerate(parameter)
+    ]
 
 
 def parse_shader_texture(texture: xml_i3d.XML_Element) -> ShaderTexture:
-    """Parses a shader texture element and returns a dictionary with texture data."""
-    return ShaderTexture(name=texture.attrib['name'], default_file=texture.attrib.get('defaultFilename', ''),
-                         template=texture.attrib.get('template', 'default'))
+    """Parses a shader texture element and returns shader texture data."""
+    return ShaderTexture(
+        name=texture.attrib['name'],
+        default_file=texture.attrib.get('defaultFilename', ''),
+        template=texture.attrib.get('template', 'default'),
+    )
 
 
 def load_shader(path: Path) -> ShaderMetadata | None:
@@ -119,67 +119,61 @@ def load_shader(path: Path) -> ShaderMetadata | None:
         return None
     shader = ShaderMetadata(path)
 
-    if (variations := root.find('Variations')) is not None:
-        for v in variations:
-            if v.tag == 'Variation':
-                # Some variations don't have a group defined, but should still use the 'base' group regardless
-                shader.variations[v.attrib.get('name')] = v.attrib.get('groups', 'base').split()
+    for variation in xml_i3d.iter_section(root, 'Variations', 'Variation'):
+        # Some variations don't have a group defined, but should still use the 'base' group regardless
+        shader.variations[variation.attrib.get('name')] = variation.attrib.get('groups', 'base').split()
 
-    if (templates := root.find('ParameterTemplates')) is not None:
-        for template in templates:
-            if template.tag == 'ParameterTemplate':
-                shader.parameter_templates[template.attrib['id']] = template.attrib['filename']
+    for template in xml_i3d.iter_section(root, 'ParameterTemplates', 'ParameterTemplate'):
+        shader.parameter_templates[template.attrib['id']] = template.attrib['filename']
 
-    if (parameters := root.find('Parameters')) is not None:
-        for p in parameters:
-            if p.tag == 'Parameter':  # Default to "base" if no group is specified
-                shader.parameters.setdefault(p.attrib.get('group', 'base'), []).extend(parse_shader_parameters(p))
+    for param in xml_i3d.iter_section(root, 'Parameters', 'Parameter'):
+        shader.parameters.setdefault(param.attrib.get('group', 'base'), []).extend(parse_shader_parameters(param))
 
-    if (textures := root.find('Textures')) is not None:
-        for t in textures:
-            if t.tag == 'Texture':  # Default to "base" if no group is specified
-                shader.textures.setdefault(t.attrib.get('group', 'base'), []).append(parse_shader_texture(t))
+    for tex in xml_i3d.iter_section(root, 'Textures', 'Texture'):
+        shader.textures.setdefault(tex.attrib.get('group', 'base'), []).append(parse_shader_texture(tex))
 
-    if (vertex_attributes := root.find('VertexAttributes')) is not None:
-        for attr in vertex_attributes:
-            if attr.tag == 'VertexAttribute':
-                shader.vertex_attributes[attr.attrib['name']] = attr.attrib.get('group', 'base')
+    for attr in xml_i3d.iter_section(root, 'VertexAttributes', 'VertexAttribute'):
+        shader.vertex_attributes[attr.attrib['name']] = attr.attrib.get('group', 'base')
 
     # Add a lookup for parameters to easily access them by name
     shader.param_lookup = {param.name: param for group in shader.parameters.values() for param in group}
     return shader
 
 
-def load_shaders_from_directory(directory: Path) -> dict:
+def load_shaders_from_directory(directory: Path) -> ShaderDict:
     """Scans a directory for .xml shader files and returns a dict of shader_name -> ShaderMetadata"""
     return {path.stem: shader for path in directory.glob('*.xml') if (shader := load_shader(path))}
 
 
 def populate_game_shaders() -> None:
-    global SHADERS_GAME
     SHADERS_GAME.clear()
 
     shader_dir = get_fs_data_path(as_path=True) / 'shaders'
-    if shader_dir.exists():
+    if shader_dir.is_dir():
         SHADERS_GAME.update(load_shaders_from_directory(shader_dir))
-    print(f"Loaded {len(SHADERS_GAME)} game shaders")
+    else:
+        logger.warning("Game shader directory does not exist: %s", shader_dir)
+    logger.info("Loaded %d game shaders", len(SHADERS_GAME))
 
 
 def populate_custom_shaders() -> None:
-    global SHADERS_CUSTOM
     SHADERS_CUSTOM.clear()
 
     try:
+        loaded_paths: set[Path] = set()
         for scene in bpy.data.scenes:
             for entry in scene.i3dio.custom_shader_folders:
                 path = Path(bpy.path.abspath(entry.path))
-                if path.exists():
+                if path in loaded_paths:
+                    continue
+                loaded_paths.add(path)
+                if path.is_dir():
                     SHADERS_CUSTOM.update(load_shaders_from_directory(path))
                 else:
-                    print(f"[Custom Shader] Folder does not exist: {entry.path}")
-    except Exception as e:
-        print("Error reading custom shader folders:", e)
-    print(f"Loaded {len(SHADERS_CUSTOM)} custom shaders")
+                    logger.warning("Custom shader folder does not exist: %s", entry.path)
+    except Exception:
+        logger.exception("Error reading custom shader folders")
+    logger.info("Loaded %d custom shaders", len(SHADERS_CUSTOM))
 
 
 @persistent
@@ -188,9 +182,11 @@ def populate_shader_cache_handler(_dummy) -> None:
     populate_custom_shaders()
 
 
-def register():
-    load_post.append(populate_shader_cache_handler)
+def register() -> None:
+    if populate_shader_cache_handler not in load_post:
+        load_post.append(populate_shader_cache_handler)
 
 
-def unregister():
-    load_post.remove(populate_shader_cache_handler)
+def unregister() -> None:
+    if populate_shader_cache_handler in load_post:
+        load_post.remove(populate_shader_cache_handler)

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -28,6 +28,15 @@ def parse(*argv, **kwargs) -> ET.ElementTree:
     return tree
 
 
+def iter_section(root: XML_Element, section_name: str, child_tag: str) -> ET.Element | None:
+    section = root.find(section_name)
+    if section is None:
+        return None
+    for child in section:
+        if child.tag == child_tag:
+            yield child
+
+
 def SubElement(*args, **kwargs) -> ET.Element:
     return ET.SubElement(*args, **kwargs)
 


### PR DESCRIPTION
- Clean up shader parameter and texture parsing
- Add clearer typing for shader metadata/cache dictionaries
- Use addon logger instead of print statements
- Make shader cache load_post registration safer