### PR TITLE
fix(file): improve path resolving and blender copy handling

### DIFF
--- a/addon/i3dio/node_classes/file.py
+++ b/addon/i3dio/node_classes/file.py
@@ -1,6 +1,7 @@
 from inspect import isabstract
 import logging
 from pathlib import Path
+import os
 import shutil
 from typing import ClassVar
 import bpy
@@ -31,7 +32,7 @@ class File(Node):
         self.blender_path = filepath  # This should be supplied as the normal blender relative path
         self.resolved_path: Path | None = None
         self.file_name = bpy.path.display_name_from_filepath(self.blender_path)
-        self.file_extension = self.blender_path[self.blender_path.rfind('.'):len(self.blender_path)]
+        self.file_extension = Path(self.blender_path).suffix
         self._xml_element = None
         super().__init__(id_, i3d, None)
 
@@ -65,73 +66,97 @@ class File(Node):
         - Other files are copied if copy_files is enabled.
         - Otherwise, relative to blend or absolute.
         """
-        self.resolved_path = utility.as_export_path(self.blender_path)
+        if (source_path := utility.as_source_path(self.blender_path)) is None:
+            self.logger.warning(
+                f"Could not resolve source path for {self.blender_path!r}. "
+                "If this is a $data path, check that the FS data path is configured."
+            )
+        elif not source_path.exists():
+            self.logger.warning(f"File {source_path!r} does not exist. The exported I3D may reference a missing file.")
 
-        if str(self.resolved_path).startswith('$data'):
-            # Game asset, always reference with $data prefix and never copy
+        self.resolved_path = utility.as_export_path(self.blender_path)
+        if utility.is_fs_builtin_path(self.resolved_path):
             self.logger.info(f"Resolved as FS $data path: {self.resolved_path}")
             return
 
         if self.i3d.settings.get('copy_files', False):
-            self._copy_file()
+            self._copy_file(source_path)
             return
 
         self.logger.info(f"Resolved filepath: {self.resolved_path}")
+
         if self.resolved_path.is_absolute():
             self.logger.warning(
                 f"File {self.blender_path!r} is outside the blend file folder; using absolute path in I3D."
             )
 
-    def _copy_file(self):
-        resolved_directory = Path()
-        write_directory = Path(self.i3d.paths['i3d_folder'])
+    def _copy_file(self, source_path: Path | None):
+        i3d_folder = Path(self.i3d.paths['i3d_folder'])
+        write_directory = i3d_folder
+        write_path_full: Path | None = None
         self.logger.info("is not an FS builtin and will be copied")
+
+        if source_path is None:
+            self.logger.warning(f"Cannot copy {self.blender_path!r} because the source path could not be resolved")
+            return
+
+        if not source_path.exists():
+            self.logger.warning(f"File {source_path!r} does not exist, cannot copy")
+            return
 
         match self.i3d.settings.get('file_structure', 'MODHUB'):
             case 'FLAT':
                 self.logger.debug("will be copied using the 'FLAT' hierarchy structure")
+                self.resolved_path = Path(f"{self.file_name}{self.file_extension}")
+                write_path_full = i3d_folder / self.resolved_path
             case 'MODHUB':
                 self.logger.debug("will be copied using the 'MODHUB' hierarchy structure")
-                resolved_directory = Path(type(self).MODHUB_FOLDER)
-                write_directory /= resolved_directory
+                self.resolved_path = Path(type(self).MODHUB_FOLDER) / f"{self.file_name}{self.file_extension}"
+                write_path_full = i3d_folder / self.resolved_path
             case 'BLENDER':
-                self.logger.debug("'will be copied using the 'BLENDER' hierarchy structure")
-                # TODO: Rewrite this to make it more than three levels above the blend file but allow deeper nesting
-                #  ,since current code just counts number of slashes
-                blender_relative_distance_limit = 3  # Limits the distance a file can be from the blend file
-                blender_path = Path(self.blender_path)
-                # relative steps to avoid copying entire folder structures ny mistake. Defaults to an absolute path.
-                if self.blender_path.count("..\\") <= blender_relative_distance_limit:
-                    # Remove relative notation and get the directory path
-                    resolved_directory = Path(*blender_path.parts[2:])
-                    write_directory /= resolved_directory
-                else:
+                self.logger.debug("will be copied using the 'BLENDER' hierarchy structure")
+
+                blend_dir = Path(bpy.data.filepath).parent.resolve(strict=False)
+                try:
+                    relative_file_path = Path(os.path.relpath(source_path, blend_dir))
+                except ValueError:
                     self.logger.debug(
-                        f"exists more than {blender_relative_distance_limit} folders away from .blend file. "
-                        f"Defaulting to absolute path and no copying."
+                        "File is on another drive than the .blend file. Defaulting to absolute path and no copying."
                     )
-                    self.resolved_path = Path(bpy.path.abspath(self.blender_path))
+                    self.resolved_path = source_path
                     return
+                
+                parent_steps = sum(1 for part in relative_file_path.parts if part == "..")
+                blender_relative_distance_limit = 3  # Limits the distance a file can be from the blend file
 
-        self.resolved_path = resolved_directory / f"{self.file_name}{self.file_extension}"
+                if parent_steps > blender_relative_distance_limit:
+                    self.logger.debug(
+                        f"File exists more than {blender_relative_distance_limit} folders away from .blend file. "
+                        "Defaulting to absolute path and no copying."
+                    )
+                    self.resolved_path = source_path
+                    return
+                
+                self.resolved_path = relative_file_path
+                write_path_full = i3d_folder / relative_file_path
 
-        # Ensure we do not overwrite the source file
-        source_path = Path(bpy.path.abspath(self.blender_path))
-        if not source_path.exists():
-            self.logger.warning(f"File {source_path!r} does not exist, cannot copy")
+        if write_path_full is None:
+            self.logger.warning("Could not resolve write path for file %r", self.blender_path)
             return
-        if self.resolved_path == source_path:
+
+        write_path_full = write_path_full.resolve(strict=False)
+        write_directory = write_path_full.parent
+
+        if write_path_full == source_path.resolve(strict=False):
             self.logger.debug("Source and destination paths are the same, no need to copy")
             return
-        # We write the file if it doesn't exist or if overwrite is allowed
-        write_path_full = write_directory / f"{self.file_name}{self.file_extension}"
-        overwrite_files = self.i3d.settings.get('overwrite_files', False)
-        if overwrite_files or not write_path_full.exists():
+
+        if self.i3d.settings.get('overwrite_files', False) or not write_path_full.exists():
             write_directory.mkdir(parents=True, exist_ok=True)
             try:
-                shutil.copy(source_path, write_directory)
+                shutil.copy(source_path, write_path_full)
             except shutil.SameFileError:
-                pass  # Ignore if source and destination is the same file
+                pass
             else:
                 self.logger.info(f"copied to {write_path_full!r}")
         else:

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -147,7 +147,7 @@ class Material(Node):
 
     def _write_texture_to_xml(self, texture_path: str, xml_key: str, bump_depth: float = None) -> None:
         """Handles writing texture file references to XML."""
-        self.logger.debug(f"Has {xml_key}: {utility.as_fs_relative_path(texture_path).as_posix()!r}")
+        self.logger.debug(f"Has {xml_key}: {utility.as_export_path(texture_path).as_posix()!r}")
         file_id = self.i3d.add_file_image(texture_path)
         self.xml_elements[xml_key] = xml_i3d.SubElement(self.element, xml_key)
         self._write_attribute('fileId', file_id, xml_key)

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -2,18 +2,16 @@
 This module contains various small utility functions, that don't really belong anywhere else
 """
 from __future__ import annotations
-from typing import Union, List
-import logging
+
 import math
-import mathutils
-import bpy
-from pathlib import Path
 import os
 import re
+from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import bpy
+import mathutils
 
-BlenderObject = Union[bpy.types.Object, bpy.types.Collection]
+BlenderObject = bpy.types.Object | bpy.types.Collection
 
 
 def vector_compare(a: mathutils.Vector, b: mathutils.Vector, epsilon: float = 0.0000001) -> bool:
@@ -51,7 +49,48 @@ def ext_user_dir(subpath: str = "", create: bool = True) -> Path:
     return Path(bpy.utils.extension_path_user(__package__, path=subpath, create=create))
 
 
-def as_fs_relative_path(filepath: str) -> Path:
+def normalize_path_separators(filepath: str | Path) -> str:
+    """Normalizes slashes for export-style path checks."""
+    return str(filepath).replace("\\", "/")
+
+
+def is_fs_builtin_path(filepath: str | Path) -> bool:
+    """
+    Returns True if the path uses the Farming Simulator '$data' prefix.
+    This only checks path syntax. It does not check whether the file exists.
+    """
+    path_str = normalize_path_separators(filepath)
+    return path_str == "$data" or path_str.startswith("$data/")
+
+
+def fs_builtin_to_disk_path(filepath: str | Path) -> Path | None:
+    """
+    Converts a '$data/...' path to a real disk path using the configured FS data path.
+    Returns None if the supplied path is not a '$data' path or if the FS data path is not configured.
+    """
+    if not is_fs_builtin_path(filepath):
+        return None
+    if not (fs_data_path := get_fs_data_path()):
+        return None
+    relative_path = normalize_path_separators(filepath).removeprefix("$data").lstrip("/")
+    return Path(bpy.path.abspath(fs_data_path)).resolve(strict=False) / relative_path
+
+
+def as_source_path(filepath: str | Path) -> Path | None:
+    """
+    Resolves a Blender/user path to the actual disk path used for validation/copying.
+    - '$data/...' paths are resolved through the configured FS data path.
+    - Blender relative paths like '//textures/foo.dds' are resolved with bpy.path.abspath.
+    - Absolute paths stay absolute.
+
+    Returns None if the source cannot be resolved, e.g. '$data' path but no FS data path is configured.
+    """
+    if is_fs_builtin_path(filepath):
+        return fs_builtin_to_disk_path(filepath)
+    return Path(bpy.path.abspath(str(filepath))).resolve(strict=False)
+
+
+def as_fs_relative_path(filepath: str | Path) -> Path:
     """
     Checks if a filepath is relative to the FS data directory
 
@@ -59,16 +98,17 @@ def as_fs_relative_path(filepath: str) -> Path:
     originates from within that directory.
 
     Args:
-        filepath (str): The filepath to check.
-
+        filepath (str | Path): The filepath to check.
     Returns:
-        str: The `$data`-replaced filepath if applicable, or a cleaned-up absolute path.
+        Path: The `$data`-replaced path if applicable, or a cleaned-up absolute path.
     """
+    if is_fs_builtin_path(filepath):
+        return Path(normalize_path_separators(filepath))
     # Resolve the absolute, normalized path to the FS data directory (if set)
     fs_data_pref = get_fs_data_path()
-    target_path = Path(bpy.path.abspath(filepath)).resolve(strict=False)
+    target_path = Path(bpy.path.abspath(str(filepath))).resolve(strict=False)
     if fs_data_pref:
-        fs_data_path = Path(bpy.path.abspath(fs_data_pref)).resolve(strict=False)
+        fs_data_path = Path(bpy.path.abspath(str(fs_data_pref))).resolve(strict=False)
         try:  # Return $data-prefixed path if inside FS data directory
             relative_to_fs = target_path.relative_to(fs_data_path)
             return (Path('$data') / relative_to_fs)
@@ -77,7 +117,7 @@ def as_fs_relative_path(filepath: str) -> Path:
     return target_path
 
 
-def as_export_path(filepath: str) -> Path:
+def as_export_path(filepath: str | Path) -> Path:
     """
     Resolves the export path for a file, for compatibility with Giants Editor and modding workflows.
 
@@ -87,14 +127,13 @@ def as_export_path(filepath: str) -> Path:
       - Otherwise, returns an absolute path.
 
     Args:
-        filepath (str): The path to the file, as used or stored by/in Blender.
-
+        filepath (str | Path): The path to the file, as used or stored by/in Blender.
     Returns:
         Path: The resolved path, either as a relative path (to the blend file) or an absolute path.
     """
-    if filepath.startswith('$data'):
+    if is_fs_builtin_path(filepath):
         # Already $data-prefixed (can happen from certain shader textures)
-        return Path(filepath)
+        return Path(normalize_path_separators(filepath))
 
     # Check if inside FS data directory
     if (fs_path := as_fs_relative_path(filepath)).parts and fs_path.parts[0] == '$data':
@@ -102,7 +141,7 @@ def as_export_path(filepath: str) -> Path:
 
     # Try to make path relative to the .blend file
     blend_dir = Path(bpy.data.filepath).parent.resolve()
-    target_path = Path(bpy.path.abspath(filepath)).resolve(strict=False)
+    target_path = Path(bpy.path.abspath(str(filepath))).resolve(strict=False)
     try:
         # NOTE: Path.relative_to (pathlib) does not support paths outside its base location before Python 3.12
         # https://docs.python.org/3.12/library/pathlib.html#pathlib.PurePath.relative_to
@@ -112,20 +151,15 @@ def as_export_path(filepath: str) -> Path:
         return target_path  # Happens if on another drive
 
 
-def sort_blender_objects_by_name(objects: List[BlenderObject]) -> List[BlenderObject]:
-    return sorted(objects, key=lambda x: x.name)
-
-
-"""
-Blenders outliner does not follow a stricly lexographical ordering, but rather what is called a "natural" ordering.
-This function implements the same ordering as per:
-https://github.com/blender/blender/blob/b0e7a6db56caf6669b6fade1622710d70b96483e/source/blender/blenlib/intern/string.c#L727,
-with the use of a regex as detailed in this answer on stackoverflow https://stackoverflow.com/a/16090640
-"""
-
-
-def sort_blender_objects_by_outliner_ordering(objects: List[BlenderObject]) -> List[BlenderObject]:
-    return sorted(objects, key=lambda s: [int(t) if t.isdigit() else t.lower() for t in re.split(r'(\d+)', s.name)])
+def sort_blender_objects_by_outliner_ordering(objects: list[BlenderObject]) -> list[BlenderObject]:
+    """
+    Blenders outliner does not follow a stricly lexographical ordering, but rather what is called a "natural" ordering.
+    This function implements the same ordering as per:
+    https://github.com/blender/blender/blob/b0e7a6db56caf6669b6fade1622710d70b96483e/source/blender/blenlib/intern/string.c#L727
+    with the use of a regex as detailed in this answer on stackoverflow https://stackoverflow.com/a/16090640
+    """
+    _split_num = re.compile(r'(\d+)')
+    return sorted(objects, key=lambda s: [int(t) if t.isdigit() else t.lower() for t in _split_num.split(s.name)])
 
 
 def get_fs_data_path(as_path: bool = False) -> str | Path:


### PR DESCRIPTION
This will improve file path resolving during export by separating source path validation from the path written into the exported I3D. This makes the file export logic more reliable for Blender-relative paths, absolute paths and farm sim $data paths.

Added few new utility helpers that likely will be useful if we decide to go for the route I wrote here https://github.com/StjerneIdioten/I3D-Blender-Addon/pull/394#issuecomment-4320272433
- Added validation for registered file paths before writing I3D file references
- Improved handling of missing/invalid teture paths
- Fixed the BLENDER copy strategy so it preserves paths relative to the .blend file folder
- Fixed an issue where aboslute path parts and filenames could accidnetally be treated as destination folders

e.g.
If a blender image node still contains a path to a deleted or moved texture:
`//textures/missing_diffuse.dds`
the exporter now warns that the source file does not exist, instead of silenetly writing a broken file reference into the I3D.

$data texture paths:
`$data/shared/default_normal.dds`
These paths are still written as `$data/...` in the exported I3D and are never copied, but the exporter will now validate them against the configured FS data path so we can warn the user about possible wrongly written path or simply invalid game asset.

BLENDER copy strategy:
e.g. a mod structure like:
```
myMod/
  shared/
    myShared_normal.dds
  vehicles/
    myVehicle1/
      myVehicle1.blend
      myVehicle1.i3d
```
a texture referenced from the blend file as:
`../../shared/myShared_normal.dds`
is now copied/exported with the same relative structure, so the I3D keeps a valid reference ot the shared texture.
Previously, absolute path parts or the filename itself could accidentally become destination folders, producing invalid nested output like:
`export/USER/Desktop/.../work/fuelSafe_normal.dds/fuelSafe_normal.dds`