### PR TITLE
refactor(export, utility): centralize close-value default checks

### DIFF
--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -124,17 +124,12 @@ class Material(Node):
 
             if self.i3d_attrs.shader_variation_name != SHADER_DEFAULT:
                 self._write_attribute('customShaderVariation', self.i3d_attrs.shader_variation_name)
-            for pname in self.i3d_attrs.shader_material_params.keys():
-                value = self.i3d_attrs.shader_material_params[pname]
+            for pname, value in self.i3d_attrs.shader_material_params.items():
                 default = self.i3d_attrs.shader_material_params.id_properties_ui(pname).as_dict().get('default')
                 if default is not None and utility.isclose_value(value, default):
                     continue
-                values = tuple(value)    
-                if len(values) == 1:
-                    value_str = f'{values[0]:.6g}'
-                else:
-                    value_str = ' '.join(f'{v:.6g}' for v in values)
-                xml_i3d.SubElement(self.element, 'CustomParameter', {'name': pname, "value": value_str})
+                elem = xml_i3d.SubElement(self.element, 'CustomParameter', {'name': pname})
+                xml_i3d.write_attribute(elem, "value", value)
 
             for texture in self.i3d_attrs.shader_material_textures:
                 self.logger.debug(f"Texture: '{texture.source}', default: {texture.default_source}")

--- a/addon/i3dio/node_classes/material.py
+++ b/addon/i3dio/node_classes/material.py
@@ -1,7 +1,5 @@
-import math
 from typing import ClassVar
 import bpy
-import mathutils
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper, ShaderImageTextureWrapper
 from .. import utility, xml_i3d
 from ..i3d import I3D
@@ -127,17 +125,16 @@ class Material(Node):
             if self.i3d_attrs.shader_variation_name != SHADER_DEFAULT:
                 self._write_attribute('customShaderVariation', self.i3d_attrs.shader_variation_name)
             for pname in self.i3d_attrs.shader_material_params.keys():
-                parameter_dict = {'name': pname}
                 value = self.i3d_attrs.shader_material_params[pname]
                 default = self.i3d_attrs.shader_material_params.id_properties_ui(pname).as_dict().get('default')
-                if len(value) == 1:
-                    if not math.isclose(value[0], default[0], abs_tol=1e-7):
-                        parameter_dict['value'] = f'{value[0]:.6g}'
-                        xml_i3d.SubElement(self.element, 'CustomParameter', parameter_dict)
+                if default is not None and utility.isclose_value(value, default):
+                    continue
+                values = tuple(value)    
+                if len(values) == 1:
+                    value_str = f'{values[0]:.6g}'
                 else:
-                    if not utility.vector_compare(mathutils.Vector(value), mathutils.Vector(default)):
-                        parameter_dict['value'] = ' '.join(f'{v:.6g}' for v in value)
-                        xml_i3d.SubElement(self.element, 'CustomParameter', parameter_dict)
+                    value_str = ' '.join(f'{v:.6g}' for v in values)
+                xml_i3d.SubElement(self.element, 'CustomParameter', {'name': pname, "value": value_str})
 
             for texture in self.i3d_attrs.shader_material_textures:
                 self.logger.debug(f"Texture: '{texture.source}', default: {texture.default_source}")

--- a/addon/i3dio/node_classes/node.py
+++ b/addon/i3dio/node_classes/node.py
@@ -197,7 +197,7 @@ class SceneGraphNode(Node):
 
         translation = matrix.to_translation()
         self.logger.debug(f"translation is {translation}")
-        if not utility.vector_compare(translation, mathutils.Vector((0, 0, 0))):
+        if not utility.isclose_value(translation, (0.0, 0.0, 0.0)):
             translation = "{0:.6g} {1:.6g} {2:.6g}".format(
                 *[x * bpy.context.scene.unit_settings.scale_length for x in translation])
 
@@ -208,7 +208,7 @@ class SceneGraphNode(Node):
 
         # Rotation, no unit scaling since it will always be degrees.
         rotation = [math.degrees(axis) for axis in matrix.to_euler('XYZ')]
-        if not utility.vector_compare(mathutils.Vector(rotation), mathutils.Vector((0, 0, 0))):
+        if not utility.isclose_value(rotation, (0.0, 0.0, 0.0)):
             rotation = "{0:.6g} {1:.6g} {2:.6g}".format(*rotation)
             self._write_attribute('rotation', rotation)
             self.logger.debug(f"has rotation(degrees): [{rotation}]")
@@ -219,7 +219,7 @@ class SceneGraphNode(Node):
                               "which is not supported in Giants Engine. Scale reset to (1, 1, 1)")
         else:
             scale = matrix.to_scale()
-            if not utility.vector_compare(scale, mathutils.Vector((1, 1, 1))):
+            if not utility.isclose_value(scale, (1.0, 1.0, 1.0)):
                 scale = "{0:.6g} {1:.6g} {2:.6g}".format(*scale)
 
                 self._write_attribute('scale', scale)

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -18,13 +18,25 @@ logger = logging.getLogger(__name__)
 BlenderObject = Union[bpy.types.Object, bpy.types.Collection]
 
 FLOAT_EXPORT_TOLERANCE = 1e-6
+_EXPORT_SEQUENCE_TYPES = (
+    tuple,
+    list,
+    mathutils.Vector,
+    mathutils.Color,
+    mathutils.Euler,
+    mathutils.Quaternion,
+    bpy.types.bpy_prop_array,
+    IDPropertyArray,
+)
 
 def _is_number(value: object) -> bool:
+    """Return True for real numeric values, but not bools."""
     return isinstance(value, Real) and not isinstance(value, bool)  # bool is a subclass of int
 
 
-def _as_export_sequence(value: object) -> tuple[Any, ...] | None:
-    if isinstance(value, (tuple, list, mathutils.Vector, mathutils.Color, bpy.types.bpy_prop_array, IDPropertyArray)):
+def _as_export_tuple(value: object) -> tuple[Any, ...] | None:
+    """Convert supported export sequences to tuples for componentwise comparison."""
+    if isinstance(value, _EXPORT_SEQUENCE_TYPES):
         return tuple(value)
     return None
 
@@ -34,23 +46,21 @@ def _isclose_item(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERAN
     b_is_number = _is_number(b)
     if a_is_number and b_is_number:
         return math.isclose(float(a), float(b), abs_tol=abs_tol, rel_tol=rel_tol)
-    if a_is_number != b_is_number:
+    if a_is_number or b_is_number:
         return False  # One is a number and the other isn't
     return a == b  # Fallback to equality for non-numeric items
 
 
 def isclose_value(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float = 0.0) -> bool:
-    """Compares export values using target-format-friendly tolerance.
-    - numbers are compared with math.isclose
-    - vectors/colors/eulers/property arrays/lists/tuples are compared componentwise
-    - numeric items use math.isclose
-    - non-numeric items use ==
-    - fallback uses ==
-
-    This is intended for default-value/export checks, not geometric distance checks.
+    """Compare export/default values using a target-format-friendly tolerance.
+    Intended for default-value/export checks, not geometric distance checks.
+    Rules:
+    - Numeric values are compared with math.isclose().
+    - Supported vector-like values are compared componentwise.
+    - Non-numeric values fall back to normal equality.
     """
-    a_seq = _as_export_sequence(a)
-    b_seq = _as_export_sequence(b)
+    a_seq = _as_export_tuple(a)
+    b_seq = _as_export_tuple(b)
     if a_seq is None and b_seq is None:
         return _isclose_item(a, b, abs_tol=abs_tol, rel_tol=rel_tol)
 

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -24,23 +24,12 @@ def _is_number(value: object) -> bool:
 
 
 def _as_export_sequence(value: object) -> tuple[Any, ...] | None:
-    if isinstance(
-        value,
-        (
-            tuple,
-            list,
-            mathutils.Vector,
-            mathutils.Euler,
-            mathutils.Color,
-            bpy.types.bpy_prop_array,
-            IDPropertyArray,
-        ),
-    ):
+    if isinstance(value, (tuple, list, mathutils.Vector, mathutils.Color, bpy.types.bpy_prop_array, IDPropertyArray)):
         return tuple(value)
     return None
 
 
-def _isclose_item(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float) -> bool:
+def _isclose_item(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float = 0.0) -> bool:
     a_is_number = _is_number(a)
     b_is_number = _is_number(b)
     if a_is_number and b_is_number:

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -49,9 +49,9 @@ def _isclose_item(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERAN
         return False  # One is a number and the other isn't
     return a == b  # Fallback to equality for non-numeric items
 
+
 def isclose_value(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float = 0.0) -> bool:
     """Compares export values using target-format-friendly tolerance.
-
     - numbers are compared with math.isclose
     - vectors/colors/eulers/property arrays/lists/tuples are compared componentwise
     - numeric items use math.isclose

--- a/addon/i3dio/utility.py
+++ b/addon/i3dio/utility.py
@@ -2,7 +2,8 @@
 This module contains various small utility functions, that don't really belong anywhere else
 """
 from __future__ import annotations
-from typing import Union, List
+from typing import Any, Union, List
+from numbers import Real
 import logging
 import math
 import mathutils
@@ -10,37 +11,67 @@ import bpy
 from pathlib import Path
 import os
 import re
+from idprop.types import IDPropertyArray
 
 logger = logging.getLogger(__name__)
 
 BlenderObject = Union[bpy.types.Object, bpy.types.Collection]
 
+FLOAT_EXPORT_TOLERANCE = 1e-6
 
-def vector_compare(a: mathutils.Vector, b: mathutils.Vector, epsilon: float = 0.0000001) -> bool:
-    """Compares two vectors elementwise, to see if they are equal
+def _is_number(value: object) -> bool:
+    return isinstance(value, Real) and not isinstance(value, bool)  # bool is a subclass of int
 
-    The function will run through the elements of vector a and compare them with vector b elementwise. If the function
-    reaches a set of values not within epsilon, it will return immediately.
 
-    Args:
-        a: The first vector
-        b: The second vector
-        epsilon: The absolute tolerance to which the elements should be within
+def _as_export_sequence(value: object) -> tuple[Any, ...] | None:
+    if isinstance(
+        value,
+        (
+            tuple,
+            list,
+            mathutils.Vector,
+            mathutils.Euler,
+            mathutils.Color,
+            bpy.types.bpy_prop_array,
+            IDPropertyArray,
+        ),
+    ):
+        return tuple(value)
+    return None
 
-    Returns:
-        True if the vectors are elementwise equal to the precision of epsilon
 
-    Raises:
-        TypeError: If the vectors aren't vectors with equal length
+def _isclose_item(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float) -> bool:
+    a_is_number = _is_number(a)
+    b_is_number = _is_number(b)
+    if a_is_number and b_is_number:
+        return math.isclose(float(a), float(b), abs_tol=abs_tol, rel_tol=rel_tol)
+    if a_is_number != b_is_number:
+        return False  # One is a number and the other isn't
+    return a == b  # Fallback to equality for non-numeric items
+
+def isclose_value(a: object, b: object, *, abs_tol: float = FLOAT_EXPORT_TOLERANCE, rel_tol: float = 0.0) -> bool:
+    """Compares export values using target-format-friendly tolerance.
+
+    - numbers are compared with math.isclose
+    - vectors/colors/eulers/property arrays/lists/tuples are compared componentwise
+    - numeric items use math.isclose
+    - non-numeric items use ==
+    - fallback uses ==
+
+    This is intended for default-value/export checks, not geometric distance checks.
     """
-    if len(a) != len(b) or not isinstance(a, mathutils.Vector) or not isinstance(b, mathutils.Vector):
-        raise TypeError("Both arguments must be vectors of equal length!")
+    a_seq = _as_export_sequence(a)
+    b_seq = _as_export_sequence(b)
+    if a_seq is None and b_seq is None:
+        return _isclose_item(a, b, abs_tol=abs_tol, rel_tol=rel_tol)
 
-    for idx in range(0, len(a)):
-        if not math.isclose(a[idx], b[idx], abs_tol=epsilon):
-            return False
+    if a_seq is None or b_seq is None:
+        return False  # One is a sequence and the other isn't
 
-    return True
+    if len(a_seq) != len(b_seq):
+        return False  # Sequences of different lengths are not close
+
+    return all(_isclose_item(x, y, abs_tol=abs_tol, rel_tol=rel_tol) for x, y in zip(a_seq, b_seq))
 
 
 def ext_user_dir(subpath: str = "", create: bool = True) -> Path:

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -202,7 +202,7 @@ def write_i3d_properties(obj, property_group, elements: Dict[str, Union[XML_Elem
                 value_to_write = property_group.i3d_map[prop_key].get('override')
             elif field_type == 'ANGLE':
                 value_to_write = math.degrees(value)
-                if math.isclose(value_to_write, default, abs_tol=0.0001):
+                if utility.isclose_value(value_to_write, default, abs_tol=0.0001):
                     continue
 
         logger.debug(f"Property '{prop_name}' with value '{value}'. Default is '{default}'")

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -176,15 +176,7 @@ def write_i3d_properties(obj, property_group, elements: Dict[str, Union[XML_Elem
         # Conversion Checks
 
         # Special case of checking floats, since these can be not equal due to floating point errors
-        if isinstance(value, float):
-            if math.isclose(value, default, abs_tol=0.0000001):
-                continue
-        elif isinstance(value, (bpy.types.bpy_prop_array, mathutils.Color)):
-            value = tuple(value)
-            if utility.vector_compare(mathutils.Vector(value), mathutils.Vector(default)):
-                continue
-        # In the case that the value is default, then just ignore it
-        elif value == default:
+        if utility.isclose_value(value, default):
             continue
         # In some cases of enums the i3d_name is actually the enum value itself. It is signaled by not having a name
         elif i3d_name is None:

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -202,9 +202,9 @@ def write_i3d_properties(obj, property_group, elements: Dict[str, Union[XML_Elem
             elif field_type == 'OVERRIDE':
                 value_to_write = property_group.i3d_map[prop_key].get('override')
             elif field_type == 'ANGLE':
-                value_to_write = math.degrees(value)
-                if utility.isclose_value(value_to_write, default, abs_tol=0.0001):
+                if utility.isclose_value(value, default):
                     continue
+                value_to_write = math.degrees(value)
 
         logger.debug(f"Property '{prop_name}' with value '{value}'. Default is '{default}'")
 

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -6,6 +6,7 @@ import math
 import logging
 import bpy
 import mathutils
+from idprop.types import IDPropertyArray
 
 from . import utility
 import xml.etree.ElementTree as ET  # Technically not following pep8, but this is the naming suggestion from the module
@@ -99,7 +100,7 @@ def write_attribute(element: XML_Element, attribute: str, value) -> None:
         write_int(element, attribute, value)
     elif isinstance(value, str):
         write_string(element, attribute, value)
-    elif isinstance(value, (list, tuple, bpy.types.bpy_prop_array, mathutils.Color, mathutils.Vector)):
+    elif isinstance(value, (list, tuple, bpy.types.bpy_prop_array, IDPropertyArray, mathutils.Color, mathutils.Vector)):
         write_vector(element, attribute, tuple(value))
     else:
         logger.warning(f"No xml attribute writing function for attribute of type '{type(value)}'")


### PR DESCRIPTION
This extracts the close-value/default comparison cleanup from #389

- Added `utility.isclose_value()` for export/default comparisons
- Uses componentwise comparison for sequence-like values
- Supports numbers, `mathutils` values, Blender property arrays, `IDPropertyArray`, lists, and tuples
- Replaced duplicated float/vector default checks in transform, shader parameter, and property export code
- Removes the need for temporary `mathutils.Vector(...)` conversions in several default checks