### PR TITLE
refactor(export): add export core pipeline foundation

### DIFF
--- a/addon/i3dio/export_core/__init__.py
+++ b/addon/i3dio/export_core/__init__.py
@@ -1,0 +1,3 @@
+from .ctx import ExportContext
+
+__all__ = [ExportContext]

--- a/addon/i3dio/export_core/ctx.py
+++ b/addon/i3dio/export_core/ctx.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, TypeVar
+
+import bpy
+import mathutils
+
+from .. import addon_logging
+from ..export_report import ExportReport
+from .ids import IdAllocator
+from .ir import ExportIR, SceneBuilder, SceneNode
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class ExportContext:
+    """Shared state for a single export run.
+    The context owns export-wide state, but should avoid becoming the place
+    where actual export work happens. Traversal/resolve/serialize modules should
+    perform the work and use this as shared state.
+    """
+
+    name: str
+    is_dev: bool
+    operator: Any
+    filepath: Path
+    depsgraph: bpy.types.Depsgraph
+    scene: bpy.types.Scene
+    conversion_matrix: mathutils.Matrix
+    settings: Mapping[str, Any]
+
+    report: ExportReport = field(default_factory=ExportReport)
+    ids: IdAllocator = field(default_factory=IdAllocator)
+    ir: ExportIR = field(default_factory=ExportIR)
+
+    features: frozenset[str] = field(init=False, repr=False)
+    conversion_matrix_inv: mathutils.Matrix = field(init=False)
+    builder: SceneBuilder = field(init=False)
+    i3d_folder: Path = field(init=False)
+
+    unit_scale: float = 1.0
+    addon_pref: bpy.types.AddonPreferences | None = None
+
+    def __post_init__(self) -> None:
+        self.filepath = Path(self.filepath)
+        self.conversion_matrix_inv = self.conversion_matrix.inverted_safe()
+        self.builder = SceneBuilder(self)
+        self.i3d_folder = self.filepath.parent
+        self.features = frozenset(self.settings.get("features_to_export", ()))
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        is_dev: bool,
+        operator: Any,
+        filepath: str | Path,
+        depsgraph: bpy.types.Depsgraph,
+        scene: bpy.types.Scene,
+        conversion_matrix: mathutils.Matrix,
+        settings: Mapping[str, Any],
+    ) -> ExportContext:
+        i3d_path = Path(filepath)
+
+        return cls(
+            name=bpy.path.display_name_from_filepath(str(i3d_path)),
+            is_dev=is_dev,
+            operator=operator,
+            filepath=i3d_path,
+            depsgraph=depsgraph,
+            scene=scene,
+            conversion_matrix=conversion_matrix,
+            settings=settings,
+            unit_scale=scene.unit_settings.scale_length,
+        )
+
+    def setting(self, key: str, default: T) -> T:
+        """Return a setting value, or default if the setting is missing."""
+        return self.settings.get(key, default)
+
+    def has_feature(self, feature: str) -> bool:
+        return feature in self.features
+
+    def ctx_logger(
+        self,
+        *,
+        name: str = "export",
+        object_name: str | None = None,
+        node_kind: str | None = None,
+        node_id: int | None = None,
+        prefix: str | None = None,
+    ) -> logging.LoggerAdapter:
+        """Create a logger adapter with export context labels."""
+
+        return addon_logging.get_export_logger(
+            name, object_name=object_name, node_kind=node_kind, node_id=node_id, prefix=prefix or ""
+        )
+
+    def node_logger(self, node: SceneNode, *, name: str = "export", prefix: str | None = None) -> logging.LoggerAdapter:
+        return self.ctx_logger(
+            name=name, object_name=node.name, node_kind=node.kind.value, node_id=node.id, prefix=prefix
+        )
+
+    def to_export(self, matrix: mathutils.Matrix) -> mathutils.Matrix:
+        """Convert a matrix from Blender space to I3D export space."""
+        return self.conversion_matrix @ matrix @ self.conversion_matrix_inv
+
+    def to_export_forward(self, matrix: mathutils.Matrix) -> mathutils.Matrix:
+        """Convert a direction/forward matrix from Blender space to I3D export space."""
+        return self.conversion_matrix @ matrix

--- a/addon/i3dio/export_core/ids.py
+++ b/addon/i3dio/export_core/ids.py
@@ -1,0 +1,26 @@
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from itertools import count
+
+
+class IdKind(Enum):
+    NODE = auto()
+    SHAPE = auto()
+    MATERIAL = auto()
+    FILE = auto()
+
+
+@dataclass(slots=True)
+class IdAllocator:
+    """Allocates stable 1-based IDs per exported I3D resource kind."""
+
+    start: int = 1
+    _iters: dict[IdKind, Iterator[int]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._iters = {k: count(self.start) for k in IdKind}
+
+    def alloc(self, kind: IdKind) -> int:
+        """Allocate a new ID for the given resource kind."""
+        return next(self._iters[kind])

--- a/addon/i3dio/export_core/ir/__init__.py
+++ b/addon/i3dio/export_core/ir/__init__.py
@@ -1,0 +1,36 @@
+from .builder import SceneBuilder
+from .graph import ExportIR, IRIndex
+from .node import (
+    BlenderRef,
+    BoneRef,
+    BoneSource,
+    CollectionSource,
+    EmitAttrs,
+    NodeKind,
+    ObjectSource,
+    ReferencePayload,
+    SceneNode,
+    ShapePayload,
+    SourceKind,
+    SyntheticSource,
+    UserAttributeEntry,
+)
+
+__all__ = [
+    "BoneRef",
+    "BoneSource",
+    "BlenderRef",
+    "CollectionSource",
+    "EmitAttrs",
+    "ExportIR",
+    "IRIndex",
+    "NodeKind",
+    "ObjectSource",
+    "SyntheticSource",
+    "ReferencePayload",
+    "SceneBuilder",
+    "SceneNode",
+    "ShapePayload",
+    "SourceKind",
+    "UserAttributeEntry",
+]

--- a/addon/i3dio/export_core/ir/builder.py
+++ b/addon/i3dio/export_core/ir/builder.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import bpy
+
+from ..ids import IdKind
+from .node import (
+    BoneRef,
+    BoneSource,
+    CollectionSource,
+    NodePayload,
+    NodeSource,
+    ObjectSource,
+    SceneNode,
+    ShapePayload,
+    SyntheticSource,
+    TransformGroupPayload,
+    UnresolvedPayload,
+)
+
+if TYPE_CHECKING:
+    from ..ctx import ExportContext
+
+
+@dataclass(slots=True)
+class SceneBuilder:
+    ctx: ExportContext
+
+    def _create_node(self, *, name: str, source: NodeSource, payload: NodePayload, parent_id: int | None) -> SceneNode:
+        """Create a new node, add it to the IR, and return the node for final specialization."""
+        node = SceneNode(
+            id=self.ctx.ids.alloc(IdKind.NODE),
+            name=name,
+            source=source,
+            payload=payload,
+            parent_id=parent_id,
+        )
+
+        self.ctx.ir.add_node(node)
+        return node
+
+    def add_object(self, obj: bpy.types.Object, *, parent_id: int | None) -> int:
+        """Add an object node to the IR."""
+        node = self._create_node(
+            name=obj.name,
+            source=ObjectSource.from_object(obj),
+            payload=UnresolvedPayload(),
+            parent_id=parent_id,
+        )
+        return node.id
+
+    def add_collection(self, collection: bpy.types.Collection, *, parent_id: int | None) -> int:
+        """Add a collection node to the IR."""
+        node = self._create_node(
+            name=collection.name,
+            source=CollectionSource.from_collection(collection),
+            payload=TransformGroupPayload(),
+            parent_id=parent_id,
+        )
+        return node.id
+
+    def add_bone(self, bone_ref: BoneRef, *, parent_id: int) -> int:
+        """Add a bone transform-group node to the IR."""
+        node = self._create_node(
+            name=bone_ref.name,
+            source=BoneSource(blender_ref=bone_ref),
+            payload=TransformGroupPayload(),
+            parent_id=parent_id,
+        )
+        return node.id
+
+    def add_derived_shape(
+        self,
+        *,
+        name: str,
+        parent_id: int,
+        shape_id: int,
+        source_obj: bpy.types.Object | None = None,
+    ) -> int:
+        """Add a shape node derived from the given source object, attached to the given parent, and return its ID."""
+        node = self._create_node(
+            name=name,
+            source=SyntheticSource(blender_ref=source_obj),
+            payload=ShapePayload(shape_id=shape_id),
+            parent_id=parent_id,
+        )
+        return node.id

--- a/addon/i3dio/export_core/ir/graph.py
+++ b/addon/i3dio/export_core/ir/graph.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+from .node import NodeKind, SceneNode, SourceKind, UserAttributeEntry
+
+
+@dataclass(slots=True)
+class IRIndex:
+    """Lookup tables built during traversal/resolve.
+    These are internal pipeline indexes, not values intended for direct XML emission.
+    """
+
+    node_ids_by_blender_ptr: dict[int, list[int]] = field(default_factory=dict)
+    mapping_id_by_node_id: dict[int, str] = field(default_factory=dict)
+    user_attributes_by_node_id: dict[int, list[UserAttributeEntry]] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExportIR:
+    """Intermediate representation of the export scene graph."""
+
+    scene_nodes: dict[int, SceneNode] = field(default_factory=dict)
+    node_order: list[int] = field(default_factory=list)
+    index: IRIndex = field(default_factory=IRIndex)
+
+    _children_by_parent_cache: dict[int | None, list[int]] | None = None
+
+    def _invalidate_children_cache(self) -> None:
+        self._children_by_parent_cache = None
+
+    def _index_node_blender_ptr(self, node: SceneNode) -> None:
+        """Index the node by its Blender data-block pointer for quick lookup during resolve."""
+        if node.source.blender_ptr is not None:
+            self.index.node_ids_by_blender_ptr.setdefault(node.source.blender_ptr, []).append(node.id)
+
+    def _children_by_parent(self) -> dict[int | None, list[int]]:
+        """Return cached parent-child relationships, keyed by parent node ID."""
+        if self._children_by_parent_cache is not None:
+            return self._children_by_parent_cache
+
+        children: dict[int | None, list[int]] = {None: []}
+
+        for node_id in self.node_order:
+            children[node_id] = []
+
+        for node_id in self.node_order:
+            node = self.scene_nodes[node_id]
+            parent_id = node.parent_id
+
+            if parent_id is None or parent_id == node_id or parent_id not in self.scene_nodes:
+                children[None].append(node_id)
+            else:
+                children[parent_id].append(node_id)
+
+        self._children_by_parent_cache = children
+        return children
+
+    def add_node(self, node: SceneNode) -> None:
+        """Add a node to the IR."""
+        if node.id in self.scene_nodes:
+            raise RuntimeError(f"Node ID {node.id} already exists in IR")
+
+        self.scene_nodes[node.id] = node
+        self.node_order.append(node.id)
+        self._index_node_blender_ptr(node)
+        self._invalidate_children_cache()
+
+    def attach(self, node_id: int, parent_id: int | None) -> None:
+        """Reparent a node. Missing nodes fail fast; self/cyclic reparenting is ignored."""
+        if node_id not in self.scene_nodes:
+            raise KeyError(f"Node ID {node_id} not found in IR")
+
+        if parent_id == node_id:
+            return
+
+        if parent_id is not None and parent_id not in self.scene_nodes:
+            raise KeyError(f"Parent node ID {parent_id} not found in IR")
+
+        current_parent_id = parent_id
+        while current_parent_id is not None:
+            if current_parent_id == node_id:
+                return
+            if (parent := self.scene_nodes.get(current_parent_id)) is None:
+                break
+
+            current_parent_id = parent.parent_id
+
+        node = self.scene_nodes[node_id]
+        if node.parent_id == parent_id:
+            return
+
+        node.parent_id = parent_id
+        self._invalidate_children_cache()
+
+    def iter_roots(self) -> Iterator[SceneNode]:
+        """Iterate root nodes (nodes with no parent)."""
+        return (self.scene_nodes[node_id] for node_id in self._children_by_parent()[None])
+
+    def iter_nodes(
+        self,
+        *,
+        kind: NodeKind | None = None,
+        source_kind: SourceKind | None = None,
+        source_object_type: str | None = None,
+        emitted_only: bool = False,
+    ) -> Iterator[SceneNode]:
+        """Iterate nodes in node_order order, optionally filtering by kind/source and/or emitted status."""
+        for node_id in self.node_order:
+            node = self.scene_nodes[node_id]
+            if kind is not None and node.kind is not kind:
+                continue
+            if source_kind is not None and node.source.kind is not source_kind:
+                continue
+            object_type = node.source_object_type_override or node.source.object_type
+            if source_object_type is not None and object_type != source_object_type:
+                continue
+            if emitted_only and not node.emit:
+                continue
+
+            yield node
+
+    def children_ids(self, parent_id: int) -> tuple[int, ...]:
+        """Return the IDs of the children of the given parent node."""
+        return tuple(self._children_by_parent().get(parent_id, ()))
+
+    def emitted_child_ids(self, node_id: int | None) -> list[int]:
+        """Return emitted children, flattening non-emitted grouping nodes."""
+        result: list[int] = []
+        for child_id in self._children_by_parent().get(node_id, ()):
+            child = self.scene_nodes[child_id]
+            if child.emit:
+                result.append(child_id)
+            else:
+                result.extend(self.emitted_child_ids(child_id))
+
+        return result
+
+    def validate_basic(self, *, require_resolved: bool = False) -> None:
+        """Validate cheap IR invariants. This is not a full consistency check, but can catch common mistakes early."""
+        seen: set[int] = set()
+
+        for node_id in self.node_order:
+            if node_id in seen:
+                raise RuntimeError(f"Node ID {node_id} appears multiple times in node_order")
+            seen.add(node_id)
+
+            if node_id not in self.scene_nodes:
+                raise RuntimeError(f"Node ID {node_id} exists in node_order but not scene_nodes")
+
+        missing_from_order = set(self.scene_nodes) - seen
+        if missing_from_order:
+            raise RuntimeError(f"Nodes missing from node_order: {sorted(missing_from_order)}")
+
+        for node in self.scene_nodes.values():
+            if node.parent_id is not None and node.parent_id not in self.scene_nodes:
+                raise RuntimeError(f"Node {node.id} has missing parent {node.parent_id}")
+
+            if node.parent_id == node.id:
+                raise RuntimeError(f"Node {node.id} cannot be its own parent")
+
+            if require_resolved and node.kind is NodeKind.UNRESOLVED:
+                raise RuntimeError(f"Node {node.id} is still unresolved")

--- a/addon/i3dio/export_core/ir/node.py
+++ b/addon/i3dio/export_core/ir/node.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, StrEnum, auto
+from typing import Any, ClassVar
+
+import bpy
+from mathutils import Matrix
+
+
+class NodeKind(StrEnum):
+    TRANSFORM_GROUP = "TransformGroup"
+    REFERENCE_NODE = "ReferenceNode"
+    SHAPE = "Shape"
+    LIGHT = "Light"
+    CAMERA = "Camera"
+
+    # Temporary kind used after traversal, before resolve/kinds has classified the node.
+    UNRESOLVED = "__UNRESOLVED__"
+
+
+class SourceKind(Enum):
+    OBJECT = auto()
+    COLLECTION = auto()
+    BONE = auto()
+    OTHER = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class BoneRef:
+    """Reference to a bone inside an armature object."""
+
+    armature_obj: bpy.types.Object
+    bone_name: str
+
+    @property
+    def name(self) -> str:
+        return self.bone_name
+
+
+BlenderRef = bpy.types.Object | bpy.types.Collection | BoneRef
+
+
+@dataclass(slots=True)
+class ObjectSource:
+    kind: ClassVar[SourceKind] = SourceKind.OBJECT
+
+    blender_ref: bpy.types.Object
+    blender_ptr: int | None = None
+    object_type: str | None = None
+
+    @classmethod
+    def from_object(cls, obj: bpy.types.Object) -> ObjectSource:
+        return cls(blender_ref=obj, blender_ptr=obj.as_pointer(), object_type=obj.type)
+
+
+@dataclass(slots=True)
+class CollectionSource:
+    kind: ClassVar[SourceKind] = SourceKind.COLLECTION
+
+    blender_ref: bpy.types.Collection
+    blender_ptr: int | None = None
+    object_type: None = None
+
+    @classmethod
+    def from_collection(cls, collection: bpy.types.Collection) -> CollectionSource:
+        return cls(blender_ref=collection, blender_ptr=collection.as_pointer())
+
+
+@dataclass(slots=True)
+class BoneSource:
+    kind: ClassVar[SourceKind] = SourceKind.BONE
+
+    blender_ref: BoneRef
+    blender_ptr: ClassVar[None] = None
+    object_type: ClassVar[None] = None
+
+
+@dataclass(slots=True)
+class SyntheticSource:
+    kind: ClassVar[SourceKind] = SourceKind.OTHER
+
+    blender_ref: BlenderRef | None = None
+    blender_ptr: ClassVar[None] = None
+    object_type: ClassVar[None] = None
+
+
+NodeSource = ObjectSource | CollectionSource | BoneSource | SyntheticSource
+
+
+@dataclass(frozen=True, slots=True)
+class UnresolvedPayload:
+    kind: ClassVar[NodeKind] = NodeKind.UNRESOLVED
+
+
+@dataclass(frozen=True, slots=True)
+class TransformGroupPayload:
+    kind: ClassVar[NodeKind] = NodeKind.TRANSFORM_GROUP
+
+
+@dataclass(slots=True)
+class ShapePayload:
+    kind: ClassVar[NodeKind] = NodeKind.SHAPE
+
+    shape_id: int | None = None
+    material_ids: list[int] | None = None
+    skin_bind_node_ids: list[int] | None = None
+
+
+@dataclass(slots=True)
+class ReferencePayload:
+    kind: ClassVar[NodeKind] = NodeKind.REFERENCE_NODE
+
+    reference_id: int | None = None
+    runtime_loaded: bool = False
+    child_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LightPayload:
+    kind: ClassVar[NodeKind] = NodeKind.LIGHT
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPayload:
+    kind: ClassVar[NodeKind] = NodeKind.CAMERA
+
+
+NodePayload = UnresolvedPayload | TransformGroupPayload | ShapePayload | ReferencePayload | LightPayload | CameraPayload
+
+
+@dataclass(slots=True)
+class EmitAttrs:
+    """Attributes intended for final I3D/XML emission."""
+
+    node: dict[str, Any] = field(default_factory=dict)
+    children: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def child(self, tag: str) -> dict[str, Any]:
+        return self.children.setdefault(tag, {})
+
+
+@dataclass(slots=True)
+class UserAttributeEntry:
+    name: str
+    type: str
+    value: Any
+
+
+@dataclass(slots=True)
+class SceneNode:
+    """A node in the export scene graph IR.
+
+    The IR stores export intent, not XML directly. Traversal creates mostly unresolved nodes,
+    resolve passes classify/fill them, and serializers later consume the finalized state.
+    """
+
+    id: int
+    name: str
+    source: NodeSource
+    payload: NodePayload
+    parent_id: int | None = None
+
+    matrix_local_export: Matrix | None = None
+    emit: bool = True
+    attrs: EmitAttrs = field(default_factory=EmitAttrs)
+    source_object_type_override: str | None = None
+
+    @property
+    def kind(self) -> NodeKind:
+        return self.payload.kind

--- a/addon/i3dio/export_core/pipeline.py
+++ b/addon/i3dio/export_core/pipeline.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import bpy
+
+from . import traverse
+from .resolve.runner import resolve_all
+
+if TYPE_CHECKING:
+    import logging
+
+    from .ctx import ExportContext
+
+
+def run_export(ctx: ExportContext, *, context: bpy.types.Context) -> list[bpy.types.Object]:
+    """Run the export pipeline and return the user-selected/source scope objects."""
+    return _PipelineRun(ctx, context).run()
+
+
+def build_ir(ctx: ExportContext, *, context: bpy.types.Context) -> list[bpy.types.Object]:
+    """Build the scene IR for the current export selection mode."""
+    return _PipelineRun(ctx, context).build_ir()
+
+
+@dataclass(slots=True)
+class _PipelineRun:
+    ctx: ExportContext
+    context: bpy.types.Context
+    logger: logging.LoggerAdapter = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.logger = self.ctx.ctx_logger(prefix="pipeline")
+
+    def run(self) -> list[bpy.types.Object]:
+        self.logger.debug("Traversal start")
+        scope_objects = self.build_ir()
+        self.logger.debug(
+            "Traversal done: nodes=%d roots=%d", len(self.ctx.ir.scene_nodes), sum(1 for _ in self.ctx.ir.iter_roots())
+        )
+
+        self.logger.debug("Resolve start")
+        resolve_all(self.ctx)
+        self.logger.debug("Resolve done")
+
+        return scope_objects
+
+    def build_ir(self) -> list[bpy.types.Object]:
+        """Build the IR for the current export selection mode."""
+        if (source_collection := self._collection_export_override()) is not None:
+            return self._build_collection_scope(source_collection, label=f"collection {source_collection.name!r}")
+
+        match selection_mode := self.ctx.operator.selection:
+            case "ALL":
+                return self._build_collection_scope(self.context.scene.collection, label="entire scene")
+            case "ACTIVE_COLLECTION":
+                collection = self.context.view_layer.active_layer_collection.collection
+                return self._build_collection_scope(collection, label=f"active collection {collection.name!r}")
+            case "ACTIVE_OBJECT":
+                if (active_object := self.context.active_object) is None:
+                    raise RuntimeError("No active object for export")
+
+                return self._build_object_scope([active_object], label=f"active object {active_object.name!r}")
+            case "SELECTED_OBJECTS":
+                if not (selected_objects := list(self.context.selected_objects)):
+                    raise RuntimeError("No objects selected for export")
+
+                return self._build_object_scope(selected_objects, label=f"{len(selected_objects)} selected objects")
+            case _:
+                raise RuntimeError(f"Unknown export selection mode: {selection_mode!r}")
+
+    def _collection_export_override(self) -> bpy.types.Collection | None:
+        if not (collection_name := self.ctx.operator.collection):
+            return None
+        if (collection := bpy.data.collections.get(collection_name)) is None:
+            raise RuntimeError(f"Collection {collection_name!r} was not found")
+
+        return collection
+
+    def _build_collection_scope(self, collection: bpy.types.Collection, *, label: str) -> list[bpy.types.Object]:
+        self.logger.info("Exporting %s", label)
+        traverse.add_collection_tree(self.ctx, collection, parent_id=None, emit_self=False)
+        return list(collection.all_objects)
+
+    def _build_object_scope(self, objects: list[bpy.types.Object], *, label: str) -> list[bpy.types.Object]:
+        self.logger.info("Exporting %s", label)
+        if self.ctx.setting("selection_traverse_children", False):
+            traverse.build_object_roots(self.ctx, objects)
+            return _objects_with_children(objects)
+
+        traverse.build_selected_roots(self.ctx, objects)
+        return objects
+
+
+def _objects_with_children(objects: list[bpy.types.Object]) -> list[bpy.types.Object]:
+    """Return roots plus recursive children, keeping each object once."""
+    result: list[bpy.types.Object] = []
+    seen: set[bpy.types.Object] = set()
+    stack = list(reversed(objects))
+
+    while stack:
+        obj = stack.pop()
+        if obj in seen:
+            continue
+
+        seen.add(obj)
+        result.append(obj)
+        stack.extend(reversed(obj.children))
+
+    return result

--- a/addon/i3dio/export_core/resolve/__init__.py
+++ b/addon/i3dio/export_core/resolve/__init__.py
@@ -1,0 +1,3 @@
+from .runner import ResolvePass, ResolvePhase, resolve_all
+
+__all__ = [ResolvePass, ResolvePhase, resolve_all]

--- a/addon/i3dio/export_core/resolve/runner.py
+++ b/addon/i3dio/export_core/resolve/runner.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from time import perf_counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+    from ..ctx import ExportContext
+    from ..ir import SceneNode
+
+
+PassFn = Callable[["ExportContext"], None]
+NodePassFn = Callable[["ExportContext", "SceneNode"], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvePass:
+    name: str
+    run: PassFn
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvePhase:
+    name: str
+    passes: tuple[ResolvePass, ...]
+
+
+def resolve_all(ctx: ExportContext, phases: tuple[ResolvePhase, ...] | None = None) -> None:
+    """Run all registered resolve phases."""
+    if phases is None:
+        phases = RESOLVE_PHASES
+
+    logger = ctx.ctx_logger(prefix="resolve")
+    logger.debug("Resolving %d scene nodes", len(ctx.ir.scene_nodes))
+
+    for phase in phases:
+        logger.debug("Resolve phase: %s", phase.name)
+
+        for resolve_pass in phase.passes:
+            label = f"{phase.name}.{resolve_pass.name}"
+            with _timed(logger, label):
+                try:
+                    resolve_pass.run(ctx)
+                except Exception:
+                    logger.exception("Resolve pass failed: %s", label)
+                    raise
+
+    _log_summary(ctx, logger)
+
+
+def ctx_pass(name: str, run: PassFn) -> ResolvePass:
+    return ResolvePass(name, run)
+
+
+def node_pass(name: str, run: NodePassFn, *, emitted_only: bool = False) -> ResolvePass:
+    return ResolvePass(name, _per_node(run, emitted_only=emitted_only))
+
+
+def phase(name: str, *passes: ResolvePass) -> ResolvePhase:
+    return ResolvePhase(name, passes)
+
+
+def _per_node(fn: NodePassFn, *, emitted_only: bool = False) -> PassFn:
+    """Adapt a node pass into an export-context pass."""
+
+    def run(ctx: ExportContext) -> None:
+        for node in ctx.ir.iter_nodes(emitted_only=emitted_only):
+            fn(ctx, node)
+
+    return run
+
+
+def _validate_ir(ctx: ExportContext) -> None:
+    ctx.ir.validate_basic()
+
+
+RESOLVE_PHASES: tuple[ResolvePhase, ...] = (
+    phase(
+        "validate",
+        ctx_pass("basic_ir", _validate_ir),
+    ),
+)
+
+
+@contextmanager
+def _timed(logger: logging.LoggerAdapter, label: str) -> Iterator[None]:
+    started_at = perf_counter()
+    try:
+        yield
+    finally:
+        logger.debug("%s: %.2f ms", label, (perf_counter() - started_at) * 1000.0)
+
+
+def _log_summary(ctx: ExportContext, logger: logging.LoggerAdapter) -> None:
+    kinds = Counter(node.kind for node in ctx.ir.iter_nodes(emitted_only=True))
+    logger.debug(
+        "Resolve summary: emitted=%d/%d kinds=%s",
+        sum(kinds.values()),
+        len(ctx.ir.scene_nodes),
+        {kind.name: count for kind, count in kinds.items()},
+    )

--- a/addon/i3dio/export_core/traverse.py
+++ b/addon/i3dio/export_core/traverse.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
+
+import bpy
+
+from ..utility import sort_blender_objects_by_outliner_ordering
+
+if TYPE_CHECKING:
+    from .ctx import ExportContext
+
+
+def build_object_roots(ctx: ExportContext, objects: Iterable[bpy.types.Object]) -> None:
+    """Build IR from the given object roots."""
+    for obj in _sorted_objects(objects):
+        add_object_tree(ctx, obj, parent_id=None)
+
+
+def build_selected_roots(ctx: ExportContext, selected_objects: list[bpy.types.Object]) -> None:
+    """Build IR from selected objects, preserving nearest selected parent relationships."""
+    roots, children_by_parent = _selected_tree(selected_objects)
+
+    def selected_children(obj: bpy.types.Object) -> Iterable[bpy.types.Object]:
+        return children_by_parent.get(obj, ())
+
+    for root in _sorted_objects(roots):
+        _walk_object_tree(ctx, root, parent_id=None, get_children=selected_children)
+
+
+def add_collection_tree(
+    ctx: ExportContext,
+    collection: bpy.types.Collection,
+    parent_id: int | None,
+    *,
+    emit_self: bool = True,
+) -> None:
+    """Add a collection and its contents to the IR."""
+    contents_parent_id = parent_id
+    if emit_self and ctx.setting("keep_collections_as_transformgroups", False):
+        contents_parent_id = ctx.builder.add_collection(collection, parent_id=parent_id)
+
+    for child_collection in collection.children.values():
+        add_collection_tree(ctx, child_collection, contents_parent_id)
+
+    root_objects = [obj for obj in collection.objects if obj.parent is None]
+    for obj in _sorted_objects(root_objects):
+        add_object_tree(ctx, obj, contents_parent_id)
+
+
+def add_object_tree(ctx: ExportContext, obj: bpy.types.Object, parent_id: int | None) -> None:
+    """Add an object and its child hierarchy to the IR."""
+    _walk_object_tree(ctx, obj, parent_id, get_children=_object_children)
+
+
+def _selected_tree(
+    selected_objects: list[bpy.types.Object],
+) -> tuple[list[bpy.types.Object], dict[bpy.types.Object, list[bpy.types.Object]]]:
+    """Build a selected-only hierarchy using the nearest selected parent for each object."""
+    selected_set = set(selected_objects)
+    children_by_parent: defaultdict[bpy.types.Object, list[bpy.types.Object]] = defaultdict(list)
+    roots: list[bpy.types.Object] = []
+
+    for obj in selected_objects:
+        parent = obj.parent
+        while parent is not None and parent not in selected_set:
+            parent = parent.parent
+
+        if parent is None:
+            roots.append(obj)
+        else:
+            children_by_parent[parent].append(obj)
+
+    return roots, {parent: _sorted_objects(children) for parent, children in children_by_parent.items()}
+
+
+def _walk_object_tree(
+    ctx: ExportContext,
+    obj: bpy.types.Object,
+    parent_id: int | None,
+    *,
+    get_children: Callable[[bpy.types.Object], Iterable[bpy.types.Object]],
+) -> None:
+    """Walk an object hierarchy, expanding instance collections and using the given child lookup."""
+    node_id = _add_object_node(ctx, obj, parent_id)
+    if node_id is None:
+        return
+
+    if obj.instance_collection is not None:
+        add_collection_tree(ctx, obj.instance_collection, node_id, emit_self=False)
+
+    for child in get_children(obj):
+        _walk_object_tree(ctx, child, node_id, get_children=get_children)
+
+
+def _add_object_node(ctx: ExportContext, obj: bpy.types.Object, parent_id: int | None) -> int | None:
+    """Create the IR node for one object, or return None when the object subtree should be skipped."""
+    if obj.i3d_attributes.exclude_from_export:
+        ctx.ctx_logger(name="export", object_name=obj.name, prefix="traverse").debug("Excluded from export")
+        return None
+
+    return ctx.builder.add_object(obj, parent_id=parent_id)
+
+
+def _object_children(obj: bpy.types.Object) -> list[bpy.types.Object]:
+    return _sorted_objects(obj.children)
+
+
+def _sorted_objects(objects: Iterable[bpy.types.Object]) -> list[bpy.types.Object]:
+    return sort_blender_objects_by_outliner_ordering(list(objects))

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -14,6 +14,8 @@ from bpy_extras.io_utils import axis_conversion
 
 from . import addon_logging
 from .constants import MERGE_GROUP_PREFIX
+from .export_core import ExportContext
+from .export_core.pipeline import run_export as run_export_core
 from .export_report import ExportReport, capture_export_report, report_to_operator
 from .i3d import I3D
 from .node_classes.merge_group import MergeGroup
@@ -30,7 +32,7 @@ BINARIZER_TIMEOUT_IN_SECONDS = 30
 def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings) -> dict:
     export_data = {}
 
-    addon_logging.addon_console_handler.setLevel(logging.INFO)
+    addon_logging.addon_console_handler.setLevel(logging.DEBUG if operator.verbose_output else logging.INFO)
 
     log_context = nullcontext()
     if operator.log_to_file:
@@ -50,14 +52,18 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
             logger.info(f"Exporting to {filepath}")
 
             depsgraph = bpy.context.evaluated_depsgraph_get()
+            conversion_matrix = axis_conversion(
+                to_forward=axis_forward,
+                to_up=axis_up,
+            ).to_4x4()
+
+            if operator.validate_export_core:
+                _validate_export_core(operator, filepath, depsgraph, conversion_matrix, settings)
 
             i3d = I3D(
                 name=bpy.path.display_name_from_filepath(filepath),
                 i3d_file_path=filepath,
-                conversion_matrix=axis_conversion(
-                    to_forward=axis_forward,
-                    to_up=axis_up,
-                ).to_4x4(),
+                conversion_matrix=conversion_matrix,
                 depsgraph=depsgraph,
                 settings=settings,
             )
@@ -66,10 +72,6 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
             logger.info("Exporter settings:")
             for setting, value in i3d.settings.items():
                 logger.info(f"  {setting}: {value}")
-
-            addon_logging.addon_console_handler.setLevel(
-                logging.DEBUG if operator.verbose_output else addon_logging.ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL
-            )
 
             # Handle case when export is triggered from a collection
             source_collection = None
@@ -134,6 +136,26 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
     addon_logging.addon_console_handler.setLevel(addon_logging.ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL)
 
     return export_data
+
+
+def _validate_export_core(operator, filepath: str, depsgraph: bpy.types.Depsgraph, conversion_matrix, settings) -> None:
+    logger.info("Validating WIP export_core pipeline")
+    ctx = ExportContext.create(
+        is_dev=False,
+        operator=operator,
+        filepath=filepath,
+        depsgraph=depsgraph,
+        scene=bpy.context.scene,
+        conversion_matrix=conversion_matrix,
+        settings=settings,
+    )
+    scope_objects = run_export_core(ctx, context=bpy.context)
+    logger.info(
+        "WIP export_core validation done: scope=%d nodes=%d roots=%d",
+        len(scope_objects),
+        len(ctx.ir.scene_nodes),
+        sum(1 for _ in ctx.ir.iter_roots()),
+    )
 
 
 def _export_active_scene_master_collection(i3d: I3D):

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -101,7 +101,7 @@ class I3D_IO_OT_export(Operator, ExportHelper):
         items=[
             ('ALL', "Everything", "Export everything from the scene master collection"),
             ('ACTIVE_COLLECTION', "Active Collection", "Export only the active collection and all its children"),
-            ('ACTIVE_OBJECT', "Active Object", "Export the active object and its children"),
+            ('ACTIVE_OBJECT', "Active Object", "Export the active object (with optional children)"),
             ('SELECTED_OBJECTS', "Selected Objects", "Export only selected objects (with optional children)"),
         ],
         default='SELECTED_OBJECTS',
@@ -110,8 +110,8 @@ class I3D_IO_OT_export(Operator, ExportHelper):
     selection_traverse_children: BoolProperty(
         name="Include Children",
         description=(
-            "When enabled, also exports all children of the selected objects. "
-            "When disabled, only the selected objects are exported, without their children."
+            "When enabled, also exports children of the active or selected objects. "
+            "When disabled, only the active or selected objects are exported, without their children."
         ),
         default=False,
     )
@@ -231,6 +231,12 @@ class I3D_IO_OT_export(Operator, ExportHelper):
         name="Generate logfile", description="Generates a log file in the same folder as the exported i3d", default=True
     )
 
+    validate_export_core: BoolProperty(
+        name="Validate WIP export_core",
+        description="Run the new work-in-progress export_core pipeline before the legacy exporter",
+        default=False,
+    )
+
     object_sorting_prefix: StringProperty(
         name="Sorting Prefix",
         description="To allow some form of control over the output ordering of the objects in the I3D file it is "
@@ -343,7 +349,7 @@ class I3D_IO_OT_export(Operator, ExportHelper):
 def export_main(layout: bpy.types.UILayout, operator, is_file_browser: bool):
     if is_file_browser:
         layout.prop(operator, 'selection')
-        if operator.selection == 'SELECTED_OBJECTS':
+        if operator.selection in {'ACTIVE_OBJECT', 'SELECTED_OBJECTS'}:
             layout.prop(operator, 'selection_traverse_children')
     layout.prop(operator, 'object_sorting_prefix')
 
@@ -387,6 +393,7 @@ def export_debug(layout, operator):
     if body:
         body.prop(operator, 'verbose_output')
         body.prop(operator, 'log_to_file')
+        body.prop(operator, 'validate_export_core')
 
 
 def export_i3d_mapping(layout, operator):


### PR DESCRIPTION
Builds on the export logging/reporting foundation added in #401.

This PR adds the first runnable foundation for the new `export_core` pipeline.

The goal is to make the new pipeline structure testable in small steps instead of only adding disconnected data structures. The new path can run Blender objects through the initial context/traversal/IR/resolve pipeline, but it does not replace/change anything on the existing exporter.

### What changed
- Add `ExportContext` as shared export-run state
- Add ID allocation helpers
- Add scene IR node/graph model
- Split IR node and graph responsibilities into separate modules
- Add `SceneBuilder` for constructing IR nodes
- Add basic traversal from Blender objects/collections into the IR
- Add resolve pass runner foundation
- Add pipeline entry point for running the new export core foundation
- Add minimal exporter/UI plumbing so the new core can be tested while keeping the legacy exporter path intact