### PR TITLE
refactor(export): add file and material resource tables

### DIFF
--- a/addon/i3dio/constants.py
+++ b/addon/i3dio/constants.py
@@ -1,0 +1,7 @@
+I3D_FILE_EXT = ".i3d"
+I3D_XML_VERSION = "1.6"
+I3D_SCHEMA_URL = "http://i3d.giants.ch/schema/i3d-1.6.xsd"
+I3D_MAX = 3.40282e38
+
+MERGE_GROUP_PREFIX = "MergedMesh_"
+SKINNED_MESH_PREFIX = "SkinnedMesh_"

--- a/addon/i3dio/debugging.py
+++ b/addon/i3dio/debugging.py
@@ -1,31 +1,106 @@
-"""Debug module which primarily contains the loggers used in the code and any helpful functions for debugging"""
-
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+ADDON_LOG_NAME = "i3dio"
+ADDON_PACKAGE_NAME = __package__ or ADDON_LOG_NAME
+
+EXPORT_LOG_FILE_ENDING = "_export_log.txt"
+ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL = logging.WARNING
+
+_LOG_FORMAT = "%(shortname)s:%(funcName)s:%(levelname)s: %(prefix)s%(message)s"
+
+
+def _short_logger_name(name: str) -> str:
+    if name == ADDON_PACKAGE_NAME:
+        return ADDON_LOG_NAME
+
+    package_prefix = f"{ADDON_PACKAGE_NAME}."
+    if name.startswith(package_prefix):
+        return f"{ADDON_LOG_NAME}.{name.removeprefix(package_prefix)}"
+
+    return name
+
+
+class SafeExtraFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        if not hasattr(record, "prefix"):
+            record.prefix = ""
+        record.shortname = _short_logger_name(record.name)
+        return super().format(record)
+
+
+def _format_prefix(prefix: object = None) -> str:
+    if not prefix:
+        return ""
+    prefix = str(prefix)
+    return prefix if prefix.endswith(": ") else f"{prefix}: "
+
+
+def _make_label(*, object_name: object = None, node_kind: object = None, node_id: object = None) -> str:
+    label = ": ".join([str(part) for part in (node_kind, object_name) if part])
+    if node_id is not None:
+        return f"{label} | id={node_id}" if label else f"id={node_id}"
+
+    return label
+
 
 # A top level logger with the module name
-addon_name = __package__
-addon_logger = logging.getLogger(addon_name)
+addon_logger = logging.getLogger(ADDON_PACKAGE_NAME)
 addon_logger.setLevel(logging.DEBUG)
 addon_logger.handlers = []  # Reset upon reload, since reloading the addon does not reload the logging module
 
 # Top-level handler for outputting to blender console
 addon_console_handler = logging.StreamHandler()
-addon_console_formatter = logging.Formatter('%(name)s:%(funcName)s:%(levelname)s: %(message)s')
-addon_console_handler.setFormatter(addon_console_formatter)
-addon_console_handler_default_level = logging.WARNING
-addon_console_handler.setLevel(addon_console_handler_default_level)
+addon_console_handler.setFormatter(SafeExtraFormatter(_LOG_FORMAT))
+addon_console_handler.setLevel(ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL)
 addon_logger.addHandler(addon_console_handler)
+addon_logger.propagate = False  # Don't propagate to root logger, which would cause duplicate messages in console
 
-# Formatting for writing to a log file
-addon_export_log_formatter = logging.Formatter('%(name)s:%(funcName)s:%(levelname)s: %(message)s')
+addon_export_log_formatter = SafeExtraFormatter(_LOG_FORMAT)
 
-# Write a little message to indicate that initialization is done
-addon_logger.info(f"Initialized logging for {addon_name} addon")
+addon_logger.info("Initialized logging for %s addon", ADDON_LOG_NAME)
 
-export_log_file_ending = '_export_log.txt'
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger under the addon root logger."""
+    return addon_logger.getChild(name)
+
+
+@contextmanager
+def export_log_file(filepath: str) -> Iterator[logging.FileHandler]:
+    handler = logging.FileHandler(filepath, mode="w", encoding="utf-8")
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(addon_export_log_formatter)
+    addon_logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        addon_logger.removeHandler(handler)
+        handler.close()
+
+
+class ContextAdapter(logging.LoggerAdapter):
+    """Inject export context such as object name, node kind, node id, and prefix."""
+
+    def process(self, msg: str, kwargs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        extra = dict(kwargs.get("extra") or {})
+
+        object_name = extra.pop("object_name", self.extra.get("object_name"))
+        node_kind = extra.pop("node_kind", self.extra.get("node_kind"))
+        node_id = extra.pop("node_id", self.extra.get("node_id"))
+        prefix = extra.pop("prefix", self.extra.get("prefix", ""))
+
+        label = _make_label(object_name=object_name, node_kind=node_kind, node_id=node_id)
+        head = f"[{label}] " if label else ""
+
+        extra["prefix"] = _format_prefix(prefix)
+        kwargs["extra"] = extra
+        return f"{head}{msg}", kwargs
 
 
 class ObjectNameAdapter(logging.LoggerAdapter):
-    def process(self, msg, kwargs):
-        object_name = kwargs.pop('object_name', self.extra['object_name'])
+    def process(self, msg: str, kwargs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        object_name = kwargs.pop("object_name", self.extra.get("object_name"))
         return f"[{object_name}] {msg}", kwargs

--- a/addon/i3dio/export_core/__init__.py
+++ b/addon/i3dio/export_core/__init__.py
@@ -1,0 +1,3 @@
+from .ctx import ExportContext
+
+__all__ = ["ExportContext"]

--- a/addon/i3dio/export_core/ctx.py
+++ b/addon/i3dio/export_core/ctx.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, TypeVar
+
+import bpy
+import mathutils
+
+from .. import debugging
+from .ids import IdAllocator
+from .ir import ExportIR, SceneBuilder, SceneNode
+from .messages import ExportMessages
+from .reporting import Reporter
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class ExportContext:
+    """Shared state for a single export run.
+    The context owns export-wide state, but should avoid becoming the place
+    where actual export work happens. Traversal/resolve/serialize modules should
+    perform the work and use this as shared state.
+    """
+
+    name: str
+    is_dev: bool
+    operator: Any
+    filepath: Path
+    depsgraph: bpy.types.Depsgraph
+    scene: bpy.types.Scene
+    conversion_matrix: mathutils.Matrix
+    settings: Mapping[str, Any]
+
+    messages: ExportMessages = field(default_factory=ExportMessages)
+    ids: IdAllocator = field(default_factory=IdAllocator)
+    ir: ExportIR = field(default_factory=ExportIR)
+
+    features: frozenset[str] = field(init=False, repr=False)
+    conversion_matrix_inv: mathutils.Matrix = field(init=False)
+    builder: SceneBuilder = field(init=False)
+    i3d_folder: Path = field(init=False)
+
+    unit_scale: float = 1.0
+    addon_pref: bpy.types.AddonPreferences | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        is_dev: bool,
+        operator: Any,
+        filepath: str | Path,
+        depsgraph: bpy.types.Depsgraph,
+        scene: bpy.types.Scene,
+        conversion_matrix: mathutils.Matrix,
+        settings: Mapping[str, Any],
+    ) -> ExportContext:
+        i3d_path = Path(filepath)
+
+        ctx = cls(
+            name=bpy.path.display_name_from_filepath(str(i3d_path)),
+            is_dev=is_dev,
+            operator=operator,
+            filepath=i3d_path,
+            depsgraph=depsgraph,
+            scene=scene,
+            conversion_matrix=conversion_matrix,
+            settings=settings,
+            unit_scale=scene.unit_settings.scale_length,
+        )
+
+        ctx.conversion_matrix_inv = conversion_matrix.inverted_safe()
+        ctx.builder = SceneBuilder(ctx)
+        ctx.i3d_folder = i3d_path.parent
+        ctx.features = frozenset(settings.get("features_to_export", ()))
+
+        return ctx
+
+    def setting(self, key: str, default: T) -> T:
+        """Return a setting value, or default if the setting is missing."""
+        return self.settings.get(key, default)
+
+    def has_feature(self, feature: str) -> bool:
+        return feature in self.features
+
+    def logger(self, name: str = "export") -> logging.Logger:
+        return debugging.get_logger(name)
+
+    def ctx_logger(
+        self,
+        *,
+        name: str = "export",
+        object_name: str | None = None,
+        node_kind: str | None = None,
+        node_id: int | None = None,
+        prefix: str | None = None,
+    ) -> logging.LoggerAdapter:
+        """Create a logger adapter with export context labels."""
+
+        return debugging.ContextAdapter(
+            self.logger(name),
+            {"object_name": object_name, "node_kind": node_kind, "node_id": node_id, "prefix": prefix or ""},
+        )
+
+    def node_logger(self, node: SceneNode, *, name: str = "export", prefix: str | None = None) -> logging.LoggerAdapter:
+        return self.ctx_logger(
+            name=name, object_name=node.name, node_kind=node.kind.value, node_id=node.id, prefix=prefix
+        )
+
+    def reporter(self, prefix: str | None = None, *, name: str = "export") -> Reporter:
+        return Reporter(self, self.ctx_logger(name=name, prefix=prefix), operator=self.operator)
+
+    def node_reporter(self, node: SceneNode, prefix: str | None = None, *, name: str = "export") -> Reporter:
+        return Reporter(self, self.node_logger(node, name=name, prefix=prefix), operator=self.operator)
+
+    def object_reporter(self, obj: bpy.types.ID, prefix: str | None = None, *, name: str = "export") -> Reporter:
+        return Reporter(
+            self,
+            self.ctx_logger(name=name, object_name=getattr(obj, "name", "?"), prefix=prefix),
+            operator=self.operator,
+        )
+
+    def to_export(self, matrix: mathutils.Matrix) -> mathutils.Matrix:
+        """Convert a matrix from Blender space to I3D export space."""
+        return self.conversion_matrix @ matrix @ self.conversion_matrix_inv
+
+    def to_export_forward(self, matrix: mathutils.Matrix) -> mathutils.Matrix:
+        """Convert a direction/forward matrix from Blender space to I3D export space."""
+        return self.conversion_matrix @ matrix

--- a/addon/i3dio/export_core/ctx.py
+++ b/addon/i3dio/export_core/ctx.py
@@ -13,6 +13,7 @@ from .ids import IdAllocator
 from .ir import ExportIR, SceneBuilder, SceneNode
 from .messages import ExportMessages
 from .reporting import Reporter
+from .resources import FileTable, MaterialTable
 
 T = TypeVar("T")
 
@@ -25,7 +26,6 @@ class ExportContext:
     perform the work and use this as shared state.
     """
 
-    name: str
     is_dev: bool
     operator: Any
     filepath: Path
@@ -34,6 +34,7 @@ class ExportContext:
     conversion_matrix: mathutils.Matrix
     settings: Mapping[str, Any]
 
+    name: str = field(init=False)
     messages: ExportMessages = field(default_factory=ExportMessages)
     ids: IdAllocator = field(default_factory=IdAllocator)
     ir: ExportIR = field(default_factory=ExportIR)
@@ -41,43 +42,24 @@ class ExportContext:
     features: frozenset[str] = field(init=False, repr=False)
     conversion_matrix_inv: mathutils.Matrix = field(init=False)
     builder: SceneBuilder = field(init=False)
+    files: FileTable = field(init=False)
+    materials: MaterialTable = field(init=False)
     i3d_folder: Path = field(init=False)
 
     unit_scale: float = 1.0
     addon_pref: bpy.types.AddonPreferences | None = None
 
-    @classmethod
-    def create(
-        cls,
-        *,
-        is_dev: bool,
-        operator: Any,
-        filepath: str | Path,
-        depsgraph: bpy.types.Depsgraph,
-        scene: bpy.types.Scene,
-        conversion_matrix: mathutils.Matrix,
-        settings: Mapping[str, Any],
-    ) -> ExportContext:
-        i3d_path = Path(filepath)
+    def __post_init__(self) -> None:
+        self.filepath = Path(self.filepath)
 
-        ctx = cls(
-            name=bpy.path.display_name_from_filepath(str(i3d_path)),
-            is_dev=is_dev,
-            operator=operator,
-            filepath=i3d_path,
-            depsgraph=depsgraph,
-            scene=scene,
-            conversion_matrix=conversion_matrix,
-            settings=settings,
-            unit_scale=scene.unit_settings.scale_length,
-        )
-
-        ctx.conversion_matrix_inv = conversion_matrix.inverted_safe()
-        ctx.builder = SceneBuilder(ctx)
-        ctx.i3d_folder = i3d_path.parent
-        ctx.features = frozenset(settings.get("features_to_export", ()))
-
-        return ctx
+        self.name = bpy.path.display_name_from_filepath(str(self.filepath))
+        self.unit_scale = self.scene.unit_settings.scale_length
+        self.conversion_matrix_inv = self.conversion_matrix.inverted_safe()
+        self.builder = SceneBuilder(self)
+        self.files = FileTable(self)
+        self.materials = MaterialTable(self)
+        self.i3d_folder = self.filepath.parent
+        self.features = frozenset(self.settings.get("features_to_export", ()))
 
     def setting(self, key: str, default: T) -> T:
         """Return a setting value, or default if the setting is missing."""

--- a/addon/i3dio/export_core/errors.py
+++ b/addon/i3dio/export_core/errors.py
@@ -1,0 +1,2 @@
+class ExportUserError(Exception):
+    """A controlled export stop with a user-friendly message."""

--- a/addon/i3dio/export_core/ids.py
+++ b/addon/i3dio/export_core/ids.py
@@ -1,0 +1,26 @@
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from itertools import count
+
+
+class IdKind(Enum):
+    NODE = auto()
+    SHAPE = auto()
+    MATERIAL = auto()
+    FILE = auto()
+
+
+@dataclass(slots=True)
+class IdAllocator:
+    """Allocates stable 1-based IDs per exported I3D resource kind."""
+
+    start: int = 1
+    _iters: dict[IdKind, Iterator[int]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._iters = {k: count(self.start) for k in IdKind}
+
+    def alloc(self, kind: IdKind) -> int:
+        """Allocate a new ID for the given resource kind."""
+        return next(self._iters[kind])

--- a/addon/i3dio/export_core/ir/__init__.py
+++ b/addon/i3dio/export_core/ir/__init__.py
@@ -1,0 +1,27 @@
+from .builder import SceneBuilder
+from .model import (
+    BlenderRef,
+    EmitAttrs,
+    ExportIR,
+    IRIndex,
+    NodeKind,
+    ReferenceNodeExt,
+    SceneNode,
+    ShapeSceneExt,
+    SourceKind,
+    UserAttributeEntry,
+)
+
+__all__ = [
+    "BlenderRef",
+    "EmitAttrs",
+    "ExportIR",
+    "IRIndex",
+    "NodeKind",
+    "ReferenceNodeExt",
+    "SceneBuilder",
+    "SceneNode",
+    "ShapeSceneExt",
+    "SourceKind",
+    "UserAttributeEntry",
+]

--- a/addon/i3dio/export_core/ir/builder.py
+++ b/addon/i3dio/export_core/ir/builder.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import bpy
+
+from ..ids import IdKind
+from .model import BlenderRef, NodeKind, SceneNode, SourceKind
+
+if TYPE_CHECKING:
+    from ..ctx import ExportContext
+
+
+def _blender_ptr(value: object) -> int | None:
+    """Get a stable integer pointer for a Blender data-block, or None if not possible."""
+    if (as_pointer := getattr(value, "as_pointer", None)) is None:
+        return None
+    try:
+        return int(as_pointer())
+    except Exception:
+        return None
+
+
+@dataclass(slots=True)
+class SceneBuilder:
+    ctx: ExportContext
+
+    def _add_node(
+        self,
+        *,
+        kind: NodeKind,
+        name: str,
+        blender_ref: BlenderRef | None,
+        source_kind: SourceKind,
+        source_ptr: int | None,
+        source_object_type: str | None,
+        parent_id: int | None,
+    ) -> int:
+        """Add a new node to the IR with the given properties and return its ID."""
+        node_id = self.ctx.ids.alloc(IdKind.NODE)
+
+        node = SceneNode(
+            id=node_id,
+            name=name,
+            kind=kind,
+            parent_id=parent_id,
+            source_kind=source_kind,
+            source_ptr=source_ptr,
+            source_object_type=source_object_type,
+            blender_ref=blender_ref,
+        )
+
+        self.ctx.ir.add_node(node)
+        return node_id
+
+    def add_object(self, obj: bpy.types.Object, *, parent_id: int | None) -> int:
+        """Add an object node to the IR."""
+        return self._add_node(
+            kind=NodeKind.UNRESOLVED,
+            name=obj.name,
+            blender_ref=obj,
+            source_kind=SourceKind.OBJECT,
+            source_ptr=_blender_ptr(obj),
+            source_object_type=obj.type,
+            parent_id=parent_id,
+        )
+
+    def add_collection(self, collection: bpy.types.Collection, *, parent_id: int | None) -> int:
+        """Add a collection node to the IR."""
+        return self._add_node(
+            kind=NodeKind.TRANSFORM_GROUP,
+            name=collection.name,
+            blender_ref=collection,
+            source_kind=SourceKind.COLLECTION,
+            source_ptr=_blender_ptr(collection),
+            source_object_type=None,
+            parent_id=parent_id,
+        )
+
+    def add_derived_shape(
+        self,
+        *,
+        name: str,
+        parent_id: int,
+        shape_id: int,
+        source_obj: bpy.types.Object | None = None,
+    ) -> int:
+        """Add a shape node derived from the given source object, attached to the given parent, and return its ID."""
+        node_id = self.ctx.ids.alloc(IdKind.NODE)
+
+        node = SceneNode(
+            id=node_id,
+            name=name,
+            kind=NodeKind.UNRESOLVED,
+            parent_id=parent_id,
+            source_kind=SourceKind.OTHER,
+            source_ptr=None,
+            source_object_type=None,
+            blender_ref=source_obj,
+        )
+        node.make_shape(shape_id=shape_id)
+
+        self.ctx.ir.add_node(node)
+        return node_id

--- a/addon/i3dio/export_core/ir/model.py
+++ b/addon/i3dio/export_core/ir/model.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from enum import Enum, StrEnum, auto
+from typing import Any, cast
+
+import bpy
+from mathutils import Matrix
+
+BlenderRef = bpy.types.Object | bpy.types.Collection
+
+
+class NodeKind(StrEnum):
+    TRANSFORM_GROUP = "TransformGroup"
+    REFERENCE_NODE = "ReferenceNode"
+    SHAPE = "Shape"
+    LIGHT = "Light"
+    CAMERA = "Camera"
+
+    # Temporary kind used after traversal, before resolve/kinds has classified the node
+    UNRESOLVED = "__UNRESOLVED__"
+
+
+class SourceKind(Enum):
+    OBJECT = auto()
+    COLLECTION = auto()
+    OTHER = auto()
+
+
+@dataclass(slots=True)
+class EmitAttrs:
+    """Attributes intended for final I3D/XML emission."""
+
+    node: dict[str, Any] = field(default_factory=dict)
+    children: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def child(self, tag: str) -> dict[str, Any]:
+        return self.children.setdefault(tag, {})
+
+
+@dataclass(slots=True)
+class ShapeSceneExt:
+    """Shape-specific scene data, attached to shape nodes."""
+
+    shape_id: int | None = None
+    material_ids: list[int] | None = None
+    skin_bind_node_ids: list[int] | None = None
+
+
+@dataclass(slots=True)
+class ReferenceNodeExt:
+    """Reference node-specific scene data, attached to reference nodes."""
+
+    reference_id: int | None = None
+    runtime_loaded: bool = False
+    child_path: str | None = None
+
+
+@dataclass(slots=True)
+class UserAttributeEntry:
+    name: str
+    type: str
+    value: Any
+
+
+@dataclass(slots=True)
+class SceneNode:
+    """A node in the export scene graph IR.
+
+    The IR stores export intent, not XML directly. Traversal creates mostly
+    unresolved nodes, resolve passes classify/fill them, and serializers later
+    consume the finalized state.
+    """
+
+    id: int
+    name: str
+    kind: NodeKind
+    source_kind: SourceKind
+    parent_id: int | None = None
+
+    matrix_local_export: Matrix | None = None
+    emit: bool = True
+    attrs: EmitAttrs = field(default_factory=EmitAttrs)
+
+    source_ptr: int | None = None
+    source_object_type: str | None = None
+    source_object_type_override: str | None = None
+    blender_ref: BlenderRef | None = None
+
+    _shape: ShapeSceneExt | None = None
+    _ref: ReferenceNodeExt | None = None
+
+    def set_kind(self, kind: NodeKind) -> None:
+        """Set the node kind and keep kind-specific extensions valid."""
+        self.kind = kind
+
+        if kind is NodeKind.SHAPE and self._shape is None:
+            self._shape = ShapeSceneExt()
+        elif kind is NodeKind.REFERENCE_NODE and self._ref is None:
+            self._ref = ReferenceNodeExt()
+
+    def make_shape(self, *, shape_id: int | None = None) -> ShapeSceneExt:
+        self.set_kind(NodeKind.SHAPE)
+        shape = self.shape
+        if shape_id is not None:
+            shape.shape_id = shape_id
+        return shape
+
+    def make_reference(
+        self, *, reference_id: int | None = None, runtime_loaded: bool | None = None, child_path: str | None = None
+    ) -> ReferenceNodeExt:
+        self.set_kind(NodeKind.REFERENCE_NODE)
+        ref = self.ref
+
+        if reference_id is not None:
+            ref.reference_id = reference_id
+        if runtime_loaded is not None:
+            ref.runtime_loaded = runtime_loaded
+        if child_path is not None:
+            ref.child_path = child_path
+
+        return ref
+
+    def _require(
+        self,
+        attr: str,
+        *,
+        expected_kind: NodeKind | None = None,
+        expected_source: SourceKind | None = None,
+    ) -> Any:
+        if expected_kind and self.kind is not expected_kind:
+            raise RuntimeError(f"Node {self.id} ({self.kind}) is not a {expected_kind}")
+
+        if expected_source and self.source_kind is not expected_source:
+            raise RuntimeError(f"Node {self.id} is not a {expected_source.name} node")
+
+        value = getattr(self, attr)
+        if value is None:
+            raise RuntimeError(f"Node {self.id}: {attr} is not initialized")
+
+        return value
+
+    @property
+    def shape(self) -> ShapeSceneExt:
+        return self._require("_shape", expected_kind=NodeKind.SHAPE)
+
+    @property
+    def ref(self) -> ReferenceNodeExt:
+        return self._require("_ref", expected_kind=NodeKind.REFERENCE_NODE)
+
+    @property
+    def obj(self) -> bpy.types.Object:
+        return cast(bpy.types.Object, self._require("blender_ref", expected_source=SourceKind.OBJECT))
+
+    @property
+    def collection(self) -> bpy.types.Collection:
+        return cast(bpy.types.Collection, self._require("blender_ref", expected_source=SourceKind.COLLECTION))
+
+    @property
+    def effective_source_object_type(self) -> str | None:
+        """Object type used for export decisions (honors override when present)."""
+        return self.source_object_type_override or self.source_object_type
+
+
+@dataclass(slots=True)
+class IRIndex:
+    """Lookup tables built during traversal/resolve.
+    These are internal pipeline indexes, not values intended for direct XML emission.
+    """
+
+    node_ids_by_blender_ptr: dict[int, list[int]] = field(default_factory=dict)
+    mapping_id_by_node_id: dict[int, str] = field(default_factory=dict)
+    user_attributes_by_node_id: dict[int, list[UserAttributeEntry]] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExportIR:
+    """Intermediate representation of the export scene graph."""
+
+    scene_nodes: dict[int, SceneNode] = field(default_factory=dict)
+    node_order: list[int] = field(default_factory=list)
+    index: IRIndex = field(default_factory=IRIndex)
+
+    _children_cache: dict[int | None, list[int]] | None = None
+    _roots_cache: list[int] | None = None
+
+    def _invalidate_caches(self) -> None:
+        self._children_cache = None
+        self._roots_cache = None
+
+    def _index_node_blender_ref(self, node: SceneNode) -> None:
+        """Index the node by its Blender reference pointer for quick lookup during resolve."""
+        if node.source_ptr is not None:
+            self.index.node_ids_by_blender_ptr.setdefault(node.source_ptr, []).append(node.id)
+
+    def _ensure_hierarchy(self) -> None:
+        """Build caches for parent-child relationships if not already built."""
+        if self._children_cache is not None and self._roots_cache is not None:
+            return
+
+        children: dict[int | None, list[int]] = {None: []}
+        roots: list[int] = []
+
+        for node_id in self.node_order:
+            children[node_id] = []
+
+        for node_id in self.node_order:
+            node = self.scene_nodes[node_id]
+            parent_id = node.parent_id
+
+            if parent_id is None or parent_id == node_id or parent_id not in self.scene_nodes:
+                roots.append(node_id)
+                children[None].append(node_id)
+            else:
+                children[parent_id].append(node_id)
+
+        self._children_cache = children
+        self._roots_cache = roots
+
+    def add_node(self, node: SceneNode, *, parent_id: int | None = None) -> None:
+        """Add a node to the IR."""
+        if node.id in self.scene_nodes:
+            raise RuntimeError(f"Node ID {node.id} already exists in IR")
+
+        if parent_id is not None:
+            node.parent_id = parent_id
+
+        self.scene_nodes[node.id] = node
+        self.node_order.append(node.id)
+        self._index_node_blender_ref(node)
+        self._invalidate_caches()
+
+    def attach(self, node_id: int, parent_id: int | None) -> None:
+        """Reparent a node. Invalid or cyclic reparenting is ignored instead of corrupting the IR."""
+        if node_id not in self.scene_nodes:
+            raise KeyError(f"Node ID {node_id} not found in IR")
+
+        if parent_id == node_id:
+            return
+
+        current_parent_id = parent_id
+        while current_parent_id is not None:
+            if current_parent_id == node_id:
+                return
+            if (parent := self.scene_nodes.get(current_parent_id)) is None:
+                break
+
+            current_parent_id = parent.parent_id
+
+        node = self.scene_nodes[node_id]
+        if node.parent_id == parent_id:
+            return
+
+        node.parent_id = parent_id
+        self._invalidate_caches()
+
+    def iter_roots(self) -> Iterator[SceneNode]:
+        """Iterate root nodes (nodes with no parent)."""
+        self._ensure_hierarchy()
+        return (self.scene_nodes[node_id] for node_id in self._roots_cache or ())
+
+    def iter_nodes(
+        self,
+        *,
+        kind: NodeKind | None = None,
+        source_kind: SourceKind | None = None,
+        source_object_type: str | None = None,
+        emitted_only: bool = False,
+    ) -> Iterator[SceneNode]:
+        """Iterate nodes in node_order order, optionally filtering by kind/source and/or emitted status."""
+        for node_id in self.node_order:
+            node = self.scene_nodes[node_id]
+            if kind is not None and node.kind is not kind:
+                continue
+            if source_kind is not None and node.source_kind is not source_kind:
+                continue
+            if source_object_type is not None and node.effective_source_object_type != source_object_type:
+                continue
+            if emitted_only and not node.emit:
+                continue
+
+            yield node
+
+    def children_ids(self, parent_id: int) -> tuple[int, ...]:
+        """Return the IDs of the children of the given parent node."""
+        self._ensure_hierarchy()
+        return tuple((self._children_cache or {}).get(parent_id, ()))
+
+    def emitted_child_ids(self, node_id: int | None) -> list[int]:
+        """Return emitted children, flattening non-emitted grouping nodes."""
+        self._ensure_hierarchy()
+
+        result: list[int] = []
+        for child_id in (self._children_cache or {}).get(node_id, ()):
+            child = self.scene_nodes[child_id]
+            if child.emit:
+                result.append(child_id)
+            else:
+                result.extend(self.emitted_child_ids(child_id))
+
+        return result
+
+    def validate_basic(self, *, require_resolved: bool = False) -> None:
+        """Validate cheap IR invariants. This is not a full consistency check, but can catch common mistakes early."""
+        seen: set[int] = set()
+
+        for node_id in self.node_order:
+            if node_id in seen:
+                raise RuntimeError(f"Node ID {node_id} appears multiple times in node_order")
+            seen.add(node_id)
+
+            if node_id not in self.scene_nodes:
+                raise RuntimeError(f"Node ID {node_id} exists in node_order but not scene_nodes")
+
+        missing_from_order = set(self.scene_nodes) - seen
+        if missing_from_order:
+            raise RuntimeError(f"Nodes missing from node_order: {sorted(missing_from_order)}")
+
+        for node in self.scene_nodes.values():
+            if node.parent_id is not None and node.parent_id not in self.scene_nodes:
+                raise RuntimeError(f"Node {node.id} has missing parent {node.parent_id}")
+
+            if node.parent_id == node.id:
+                raise RuntimeError(f"Node {node.id} cannot be its own parent")
+
+            if node.kind is NodeKind.SHAPE and node._shape is None:
+                raise RuntimeError(f"Shape node {node.id} has no shape extension")
+
+            if node.kind is NodeKind.REFERENCE_NODE and node._ref is None:
+                raise RuntimeError(f"Reference node {node.id} has no reference extension")
+
+            if require_resolved and node.kind is NodeKind.UNRESOLVED:
+                raise RuntimeError(f"Node {node.id} is still unresolved")

--- a/addon/i3dio/export_core/messages.py
+++ b/addon/i3dio/export_core/messages.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+
+
+class Severity(Enum):
+    WARNING = auto()
+    ERROR = auto()
+
+
+@dataclass(slots=True)
+class ExportMessage:
+    severity: Severity
+    text: str
+    object_name: str | None = None
+    code: str | None = None  # optional stable identifier
+
+
+@dataclass(slots=True)
+class ExportMessages:
+    items: list[ExportMessage] = field(default_factory=list)
+    _dedupe: set[tuple[Severity, str, str | None, str | None]] = field(default_factory=set)
+
+    def add(
+        self,
+        severity: Severity,
+        text: str,
+        *,
+        object_name: str | None = None,
+        dedupe: bool = True,
+        code: str | None = None,
+    ) -> None:
+        key = (severity, text, object_name, code)
+        if dedupe:
+            if key in self._dedupe:
+                return
+            self._dedupe.add(key)
+        self.items.append(ExportMessage(severity, text, object_name, code))
+
+    def warning(self, text: str, *, object_name: str | None = None, **kw) -> None:
+        self.add(Severity.WARNING, text, object_name=object_name, **kw)
+
+    def error(self, text: str, *, object_name: str | None = None, **kw) -> None:
+        self.add(Severity.ERROR, text, object_name=object_name, **kw)

--- a/addon/i3dio/export_core/reporting.py
+++ b/addon/i3dio/export_core/reporting.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from .errors import ExportUserError
+from .messages import ExportMessage, Severity
+
+
+@dataclass(slots=True)
+class Reporter:
+    ctx: Any
+    log: logging.LoggerAdapter
+    operator: Any | None = None
+
+    def _default_object_name(self) -> str | None:
+        extra = getattr(self.log, "extra", None)
+        return extra.get("object_name") if isinstance(extra, dict) else None
+
+    @staticmethod
+    def _msg_text(msg: str, args: tuple[object, ...]) -> str:
+        return (msg % args) if args else msg
+
+    def info(self, msg: str, *args, stacklevel: int = 2) -> None:
+        self.log.info(msg, *args, stacklevel=stacklevel)
+
+    def debug(self, msg: str, *args, stacklevel: int = 2) -> None:
+        self.log.debug(msg, *args, stacklevel=stacklevel)
+
+    def _log_and_record(
+        self,
+        level: str,
+        msg: str,
+        args: tuple,
+        *,
+        object_name: str | None,
+        code: str | None,
+        report: bool,
+        stacklevel: int,
+    ) -> str:
+        """Common logic for warning/error: log, record message, optionally report to operator."""
+        getattr(self.log, level)(msg, *args, stacklevel=stacklevel + 1)
+        text = self._msg_text(msg, args)
+        obj = object_name or self._default_object_name()
+        getattr(self.ctx.messages, level)(text, object_name=obj, code=code)
+        if report and self.operator:
+            self.operator.report({level.upper()}, text)
+        return text
+
+    def warning(
+        self,
+        msg: str,
+        *args,
+        object_name: str | None = None,
+        code: str | None = None,
+        report: bool = False,
+        stacklevel: int = 2,
+    ) -> None:
+        self._log_and_record(
+            "warning", msg, args, object_name=object_name, code=code, report=report, stacklevel=stacklevel
+        )
+
+    def error(
+        self,
+        msg: str,
+        *args,
+        object_name: str | None = None,
+        code: str | None = None,
+        report: bool = False,
+        stacklevel: int = 2,
+    ) -> None:
+        self._log_and_record(
+            "error", msg, args, object_name=object_name, code=code, report=report, stacklevel=stacklevel
+        )
+
+    def exception(
+        self,
+        msg: str,
+        *args,
+        object_name: str | None = None,
+        code: str | None = None,
+        severity: Severity = Severity.WARNING,
+        stacklevel: int = 2,
+    ) -> None:
+        self.log.exception(msg, *args, stacklevel=stacklevel)
+        text = self._msg_text(msg, args)
+        obj = object_name or self._default_object_name()
+        record = self.ctx.messages.error if severity is Severity.ERROR else self.ctx.messages.warning
+        record(text, object_name=obj, code=code)
+
+    def abort(
+        self, msg: str, *args, object_name: str | None = None, code: str | None = None, report: bool = True
+    ) -> None:
+        """Log error, record message, optionally report to operator, and raise ExportUserError."""
+        text = self._log_and_record("error", msg, args, object_name=object_name, code=code, report=report, stacklevel=2)
+        raise ExportUserError(text)
+
+
+def _fmt_message(m: ExportMessage) -> str:
+    return f"[{m.object_name}] {m.text}" if m.object_name else m.text
+
+
+def report_messages_to_operator(ctx: Any, *, limit: int = 10, code_summary_limit: int = 5) -> None:
+    if not (operator := getattr(ctx, "operator", None)) or limit <= 0 or not ctx.messages.items:
+        return
+
+    by_severity = {s: [m for m in ctx.messages.items if m.severity is s] for s in Severity}
+
+    # Show errors first, then warnings, up to limit
+    shown: list[ExportMessage] = []
+    for sev in (Severity.ERROR, Severity.WARNING):
+        for m in by_severity[sev]:
+            if len(shown) >= limit:
+                break
+            operator.report({sev.name}, _fmt_message(m))
+            shown.append(m)
+
+    # Summarize remaining by code
+    remaining = [m for m in by_severity[Severity.ERROR] + by_severity[Severity.WARNING] if m not in shown]
+    if not remaining:
+        return
+
+    counts = Counter(m.code for m in remaining if m.code)
+    accounted = 0
+    for code, n in counts.most_common(code_summary_limit):
+        operator.report({"WARNING"}, f"...and {n} more: {code} (see export log)")
+        accounted += n
+
+    if (hidden := len(remaining) - accounted) > 0:
+        operator.report({"WARNING"}, f"...and {hidden} more messages (see export log).")

--- a/addon/i3dio/export_core/resources/__init__.py
+++ b/addon/i3dio/export_core/resources/__init__.py
@@ -1,0 +1,14 @@
+from .base import IdEntryTable
+from .files import FileEntry, FileKind, FileTable
+from .materials import DEFAULT_MATERIAL_NAME, MaterialEntry, MaterialKey, MaterialTable
+
+__all__ = [
+    "DEFAULT_MATERIAL_NAME",
+    "FileEntry",
+    "FileKind",
+    "FileTable",
+    "IdEntryTable",
+    "MaterialEntry",
+    "MaterialKey",
+    "MaterialTable",
+]

--- a/addon/i3dio/export_core/resources/base.py
+++ b/addon/i3dio/export_core/resources/base.py
@@ -1,0 +1,64 @@
+from collections.abc import Callable, Hashable, Iterator
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+KeyT = TypeVar("KeyT", bound=Hashable)
+EntryT = TypeVar("EntryT")
+
+
+@dataclass(slots=True)
+class IdEntryTable(Generic[KeyT, EntryT]):
+    """Base table for exported resources with stable numeric IDs."""
+
+    _by_key: dict[KeyT, int] = field(default_factory=dict, init=False, repr=False)
+    _entries: dict[int, EntryT] = field(default_factory=dict, init=False, repr=False)
+
+    def get_id(self, key: KeyT) -> int | None:
+        return self._by_key.get(key)
+
+    def get_entry(self, entry_id: int) -> EntryT:
+        return self._entries[entry_id]
+
+    def get_existing(self, key: KeyT) -> EntryT | None:
+        if (entry_id := self.get_id(key)) is None:
+            return None
+        return self._entries[entry_id]
+
+    def register(self, *, key: KeyT, entry_id: int, entry: EntryT) -> None:
+        """Register a new entry with the given key and ID. Raises if the key or ID is already registered."""
+        if key in self._by_key:
+            raise ValueError(f"{type(self).__name__}: key is already registered: {key!r}")
+        if entry_id in self._entries:
+            raise ValueError(f"{type(self).__name__}: entry ID is already registered: {entry_id}")
+
+        self._by_key[key] = entry_id
+        self._entries[entry_id] = entry
+
+    def get_or_create(self, key: KeyT, factory: Callable[[], tuple[int, EntryT]]) -> tuple[int, EntryT, bool]:
+        """Return an existing entry for key, or create and register a new one.
+        Returns:
+            A tuple of (entry_id, entry, created) where created is True if a new entry was created.
+        """
+        if (entry_id := self.get_id(key)) is not None:
+            return entry_id, self._entries[entry_id], False
+
+        entry_id, entry = factory()
+        self.register(key=key, entry_id=entry_id, entry=entry)
+        return entry_id, entry, True
+
+    def iter_items(self) -> Iterator[tuple[int, EntryT]]:
+        """Iterate ID/entry pairs in stable numeric ID order."""
+        for entry_id in sorted(self._entries):
+            yield entry_id, self._entries[entry_id]
+
+    def iter_entries(self) -> Iterator[EntryT]:
+        """Iterate entries in stable numeric ID order."""
+        for _, entry in self.iter_items():
+            yield entry
+
+    def entries(self) -> list[EntryT]:
+        """Return entries in stable numeric ID order."""
+        return list(self.iter_entries())
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/addon/i3dio/export_core/resources/files.py
+++ b/addon/i3dio/export_core/resources/files.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, Literal
+
+from ..ids import IdKind
+from .base import IdEntryTable
+
+if TYPE_CHECKING:
+    from ..ctx import ExportContext
+
+
+FileKind = Literal["image", "shader", "reference", "generic"]
+FileKey = tuple[FileKind, str]
+
+
+MODHUB_FOLDER: Final[Mapping[FileKind, str]] = {
+    "image": "textures",
+    "shader": "shaders",
+    "reference": "assets",
+    "generic": "",
+}
+
+
+@dataclass(slots=True)
+class FileEntry:
+    id: int
+    kind: FileKind
+    # Path/reference as stored in Blender, e.g. "//textures/foo.dds", absolute path, or "$data/..."
+    blender_path: str
+    # Real disk path used for validation/copying. None if it cannot be resolved.
+    source_path: Path | None = None
+    # Final reference written to the I3D XML, e.g. "textures/foo.dds" or "$data/shared/foo.dds".
+    export_path: str | None = None
+
+
+@dataclass(slots=True)
+class FileTable(IdEntryTable[FileKey, FileEntry]):
+    """Deduplicates file references and provides stable file IDs."""
+
+    ctx: ExportContext
+
+    def _make_entry(self, *, kind: FileKind, blender_path: str) -> tuple[int, FileEntry]:
+        file_id = self.ctx.ids.alloc(IdKind.FILE)
+        return file_id, FileEntry(id=file_id, kind=kind, blender_path=blender_path)
+
+    def add(self, *, kind: FileKind, blender_path: str) -> int:
+        key = (kind, blender_path)
+        file_id, _, _ = self.get_or_create(key, lambda: self._make_entry(kind=kind, blender_path=blender_path))
+        return file_id
+
+    def add_image(self, blender_path: str) -> int:
+        return self.add(kind="image", blender_path=blender_path)
+
+    def add_shader(self, blender_path: str) -> int:
+        return self.add(kind="shader", blender_path=blender_path)
+
+    def add_reference(self, blender_path: str) -> int:
+        return self.add(kind="reference", blender_path=blender_path)
+
+    def add_generic(self, blender_path: str) -> int:
+        return self.add(kind="generic", blender_path=blender_path)

--- a/addon/i3dio/export_core/resources/materials.py
+++ b/addon/i3dio/export_core/resources/materials.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import bpy
+
+from ..ids import IdKind
+from ..ir import EmitAttrs
+from .base import IdEntryTable
+
+if TYPE_CHECKING:
+    from ..ctx import ExportContext
+
+DEFAULT_MATERIAL_NAME = "i3d_default_material"
+
+
+@dataclass(frozen=True, slots=True)
+class MaterialKey:
+    material_ptr: int  # 0 for None/export-side default material
+    export_name: str  # final Material@name (slot override or datablock name)
+
+
+@dataclass(slots=True)
+class MaterialEntry:
+    id: int
+    key: MaterialKey
+    blender_material: bpy.types.Material | None
+    attrs: EmitAttrs = field(default_factory=EmitAttrs)
+    extra_children: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def requires_tangents(self) -> bool:
+        """Return True if tangent export is required for this material."""
+        if (mat := self.blender_material) is None:
+            return False
+
+        req_attrs = mat.i3d_attributes.required_vertex_attributes
+        return "Normalmap" in self.attrs.children or any("tangent" in attr.name.lower() for attr in req_attrs)
+
+    def requires_vcol(self) -> bool:
+        """Return True if this material requires vertex colors."""
+        if (mat := self.blender_material) is None:
+            return False
+        return any("color" in attr.name.lower() for attr in mat.i3d_attributes.required_vertex_attributes)
+
+    def get_slot_name(self) -> str | None:
+        """Return the optional materialSlotName, or None if disabled."""
+        if (mat := self.blender_material) is None:
+            return None
+        i3d_attrs = mat.i3d_attributes
+        if not i3d_attrs.use_material_slot_name:
+            return None
+        return i3d_attrs.material_slot_name or mat.name
+
+
+@dataclass(slots=True)
+class MaterialTable(IdEntryTable[MaterialKey, MaterialEntry]):
+    """Deduplicates materials and provides stable material IDs."""
+
+    ctx: ExportContext
+    _default_id: int | None = field(default=None, init=False, repr=False)
+
+    def _make_entry(
+        self, *, key: MaterialKey, blender_material: bpy.types.Material | None
+    ) -> tuple[int, MaterialEntry]:
+        mid = self.ctx.ids.alloc(IdKind.MATERIAL)
+        return mid, MaterialEntry(id=mid, key=key, blender_material=blender_material)
+
+    def _make_key(self, mat: bpy.types.Material | None, export_name: str | None) -> MaterialKey:
+        if mat is None:
+            return MaterialKey(0, export_name or DEFAULT_MATERIAL_NAME)
+        return MaterialKey(mat.as_pointer(), export_name or mat.name)
+
+    @property
+    def default_id(self) -> int:
+        if self._default_id is None:
+            self._default_id = self.get_or_add(None, export_name=DEFAULT_MATERIAL_NAME)
+        return self._default_id
+
+    def get_or_add(self, mat: bpy.types.Material | None, *, export_name: str | None = None) -> int:
+        key = self._make_key(mat, export_name)
+        mat_id, _, _ = self.get_or_create(key, lambda: self._make_entry(key=key, blender_material=mat))
+
+        if mat is None and key.export_name == DEFAULT_MATERIAL_NAME:
+            self._default_id = mat_id
+        return mat_id

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -11,7 +11,8 @@ import bpy
 from addon_utils import module_bl_info
 from bpy_extras.io_utils import axis_conversion
 
-from . import debugging, xml_i3d
+from . import debugging
+from .constants import I3D_FILE_EXT, MERGE_GROUP_PREFIX
 from .i3d import I3D
 from .node_classes.merge_group import MergeGroup
 from .node_classes.node import SceneGraphNode
@@ -30,7 +31,7 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
 
     if operator.log_to_file:
         # Remove the file ending from path and append log specific naming
-        filename = filepath[0 : len(filepath) - len(xml_i3d.file_ending)] + debugging.export_log_file_ending
+        filename = filepath[0 : len(filepath) - len(I3D_FILE_EXT)] + debugging.export_log_file_ending
         log_file_handler = logging.FileHandler(filename, mode='w')
         log_file_handler.setLevel(logging.DEBUG)
         log_file_handler.setFormatter(debugging.addon_export_log_formatter)
@@ -250,7 +251,7 @@ def _add_object_to_i3d(i3d: I3D, obj: BlenderObject, parent: SceneGraphNode = No
             elif 'MERGE_GROUPS' in i3d.settings['features_to_export'] and obj.i3d_merge_group_index > -1:
                 blender_merge_group = bpy.context.scene.i3dio_merge_groups[obj.i3d_merge_group_index]
                 i3d.merge_groups.setdefault(
-                    obj.i3d_merge_group_index, MergeGroup(xml_i3d.merge_group_prefix + blender_merge_group.name)
+                    obj.i3d_merge_group_index, MergeGroup(MERGE_GROUP_PREFIX + blender_merge_group.name)
                 )
                 node = i3d.add_merge_group_node(obj, _parent)
 

--- a/addon/i3dio/exporter.py
+++ b/addon/i3dio/exporter.py
@@ -31,7 +31,7 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
 
     if operator.log_to_file:
         # Remove the file ending from path and append log specific naming
-        filename = filepath[0 : len(filepath) - len(I3D_FILE_EXT)] + debugging.export_log_file_ending
+        filename = filepath[0 : len(filepath) - len(I3D_FILE_EXT)] + debugging.EXPORT_LOG_FILE_ENDING
         log_file_handler = logging.FileHandler(filename, mode='w')
         log_file_handler.setLevel(logging.DEBUG)
         log_file_handler.setFormatter(debugging.addon_export_log_formatter)
@@ -49,7 +49,7 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
     if operator.verbose_output:
         debugging.addon_console_handler.setLevel(logging.DEBUG)
     else:
-        debugging.addon_console_handler.setLevel(debugging.addon_console_handler_default_level)
+        debugging.addon_console_handler.setLevel(debugging.ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL)
 
     time_start = time.time()
 
@@ -129,7 +129,7 @@ def export_blend_to_i3d(operator, filepath: str, axis_forward, axis_up, settings
         pass
 
     debugging.addon_logger.removeHandler(log_file_handler)
-    debugging.addon_console_handler.setLevel(debugging.addon_console_handler_default_level)
+    debugging.addon_console_handler.setLevel(debugging.ADDON_CONSOLE_HANDLER_DEFAULT_LEVEL)
     return export_data
 
 

--- a/addon/i3dio/node_classes/skinned_mesh.py
+++ b/addon/i3dio/node_classes/skinned_mesh.py
@@ -10,7 +10,7 @@ from collections import ChainMap
 import bpy
 import mathutils
 
-from .. import xml_i3d
+from ..constants import SKINNED_MESH_PREFIX
 from ..i3d import I3D
 from .node import SceneGraphNode, TransformGroupNode
 from .shape import EvaluatedMesh, IndexedTriangleSet, ShapeNode
@@ -194,7 +194,7 @@ class SkinnedMeshShapeNode(ShapeNode):
             for modifier in skinned_mesh_object.modifiers
             if modifier.type == 'ARMATURE' and modifier.object
         ]
-        self.skinned_mesh_name = f"{xml_i3d.skinned_mesh_prefix}{skinned_mesh_object.data.name}"
+        self.skinned_mesh_name = f"{SKINNED_MESH_PREFIX}{skinned_mesh_object.data.name}"
         self.bone_mapping = ChainMap(*[armature.bone_mapping for armature in self.armature_nodes])
         super().__init__(id_=id_, shape_object=skinned_mesh_object, i3d=i3d, parent=parent)
 

--- a/addon/i3dio/ui/exporter.py
+++ b/addon/i3dio/ui/exporter.py
@@ -4,7 +4,8 @@ from bpy.types import Operator, Panel
 from bpy_extras.io_utils import ExportHelper, orientation_helper
 
 from .. import __package__ as base_package
-from .. import exporter, xml_i3d
+from .. import exporter
+from ..constants import I3D_FILE_EXT
 
 classes = []
 
@@ -78,9 +79,9 @@ class I3D_IO_OT_export(Operator, ExportHelper):
     bl_label = "Export I3D"
     bl_options = {'UNDO', 'PRESET'}  # 'PRESET' enables the preset dialog for saving settings as preset
 
-    filename_ext = xml_i3d.file_ending
+    filename_ext = I3D_FILE_EXT
     filter_glob: StringProperty(
-        default=f"*{xml_i3d.file_ending}",
+        default=f"*{I3D_FILE_EXT}",
         options={'HIDDEN'},
         maxlen=255,
     )
@@ -501,7 +502,7 @@ class I3D_IO_PT_i3d_scene(Panel):
 
 # File -> Export item
 def menu_func_export(self, context):
-    self.layout.operator(I3D_IO_OT_export.bl_idname, text="I3D (.i3d)")
+    self.layout.operator(I3D_IO_OT_export.bl_idname, text=f"I3D ({I3D_FILE_EXT})")
 
 
 def register():

--- a/addon/i3dio/ui/light.py
+++ b/addon/i3dio/ui/light.py
@@ -3,7 +3,7 @@ from bl_operators.presets import AddPresetBase
 from bpy.props import BoolProperty, EnumProperty, FloatProperty, FloatVectorProperty, PointerProperty
 from bpy.types import Operator, Panel
 
-from ..xml_i3d import i3d_max
+from ..constants import I3D_MAX
 from . import presets
 from .helper_functions import i3d_property
 
@@ -154,7 +154,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['range']['default'],
         precision=3,
         min=0.01,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0.01,
         soft_max=65535,
     )
@@ -172,7 +172,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         precision=3,
         unit='ROTATION',
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=180,
     )
@@ -189,7 +189,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['drop_off']['default'],
         precision=3,
         min=0,
-        max=5,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=5,
     )
@@ -220,8 +220,8 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         description="Depends on 'Cast Shadow Map' being 'True'",
         default=i3d_map['shadow_map_slope_scale_bias']['default'],
         precision=3,
-        min=-i3d_max,
-        max=i3d_max,
+        min=-I3D_MAX,
+        max=I3D_MAX,
         soft_min=-10,
         soft_max=10,
     )
@@ -231,8 +231,8 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         description="Depends on 'Cast Shadow Map' being 'True'",
         default=i3d_map['shadow_map_slope_clamp']['default'],
         precision=3,
-        min=-i3d_max,
-        max=i3d_max,
+        min=-I3D_MAX,
+        max=I3D_MAX,
         soft_min=-10,
         soft_max=10,
     )
@@ -262,7 +262,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['shadow_far_distance']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=65535,
     )
@@ -273,7 +273,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['shadow_extrusion_distance']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=100,
     )
@@ -291,7 +291,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['split_distance_1']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=500,
     )
@@ -302,7 +302,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['split_distance_2']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=500,
     )
@@ -313,7 +313,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['split_distance_3']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=500,
     )
@@ -324,7 +324,7 @@ class I3DNodeLightAttributes(bpy.types.PropertyGroup):
         default=i3d_map['split_distance_4']['default'],
         precision=3,
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=500,
     )

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -13,7 +13,7 @@ from bpy.props import (
 )
 from bpy.types import Operator, Panel
 
-from ..xml_i3d import i3d_max
+from ..constants import I3D_MAX
 from . import light, mesh, presets
 from .collision_data import COLLISIONS
 from .helper_functions import i3d_property
@@ -142,7 +142,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Anything above this distance to the camera, wont be rendered",
         default=i3d_map['clip_distance']['default'],
         min=0.0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=65535.0,
     )
@@ -152,7 +152,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Anything below this distance to the camera, wont be rendered",
         default=i3d_map['min_clip_distance']['default'],
         min=0.0,
-        max=i3d_max,
+        max=I3D_MAX,
         soft_min=0,
         soft_max=65535.0,
     )
@@ -284,7 +284,7 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         size=5,
         default=i3d_map['split_uvs']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
 
     use_parent: BoolProperty(
@@ -386,31 +386,31 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Projection distance",
         default=i3d_map['projection_distance']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
     projection_angle: FloatProperty(
         name="Projection Angle",
         description="Projection angle",
         default=i3d_map['projection_angle']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
     drive_force_limit: FloatProperty(
         name="Drive Force Limit",
         description="Drive Force Limit",
         default=i3d_map['drive_force_limit']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
     drive_spring: FloatProperty(
-        name="Drive Spring", description="Drive Spring", default=i3d_map['drive_spring']['default'], min=0, max=i3d_max
+        name="Drive Spring", description="Drive Spring", default=i3d_map['drive_spring']['default'], min=0, max=I3D_MAX
     )
     drive_damping: FloatProperty(
         name="Drive Damping",
         description="Drive Damping",
         default=i3d_map['drive_damping']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
     breakable_joint: BoolProperty(
         name="Breakable", description="Breakable joint", default=i3d_map['breakable_joint']['default']
@@ -420,14 +420,14 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         description="Joint break force",
         default=i3d_map['joint_break_force']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
     joint_break_torque: FloatProperty(
         name="Break Torque",
         description="Joint break torque",
         default=i3d_map['joint_break_torque']['default'],
         min=0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
 
     exclude_from_export: BoolProperty(

--- a/addon/i3dio/ui/shader_parser.py
+++ b/addon/i3dio/ui/shader_parser.py
@@ -7,6 +7,7 @@ import bpy
 from bpy.app.handlers import load_post, persistent
 
 from .. import xml_i3d
+from ..constants import I3D_MAX
 from ..debugging import addon_logger
 from ..utility import get_fs_data_path
 
@@ -18,8 +19,8 @@ class ShaderParameter:
     name: str
     component_count: int
     default_value: list[float]
-    min_value: float = -xml_i3d.i3d_max
-    max_value: float = xml_i3d.i3d_max
+    min_value: float = -I3D_MAX
+    max_value: float = I3D_MAX
     description: str = ''
     template: str = 'default'
 
@@ -73,11 +74,11 @@ def parse_shader_parameters(parameter: xml_i3d.XML_Element) -> list[ShaderParame
     description = parameter.attrib.get("description", "").replace("\\n", "\n")
 
     default_value = _parse_float_list(parameter.attrib.get('defaultValue'))
-    min_values = _parse_float_list(parameter.attrib.get('minValue'), min(-xml_i3d.i3d_max, min(default_value)))
-    max_values = _parse_float_list(parameter.attrib.get('maxValue'), max(xml_i3d.i3d_max, max(default_value)))
-    # Blender supports only a single min/max per prop, so if all are the same, use that; else fallback to i3d_max
-    min_single = min_values[0] if all(x == min_values[0] for x in min_values) else -xml_i3d.i3d_max
-    max_single = max_values[0] if all(x == max_values[0] for x in max_values) else xml_i3d.i3d_max
+    min_values = _parse_float_list(parameter.attrib.get('minValue'), min(-I3D_MAX, min(default_value)))
+    max_values = _parse_float_list(parameter.attrib.get('maxValue'), max(I3D_MAX, max(default_value)))
+    # Blender supports only a single min/max per prop, so if all are the same, use that; else fallback to I3D_MAX
+    min_single = min_values[0] if all(x == min_values[0] for x in min_values) else -I3D_MAX
+    max_single = max_values[0] if all(x == max_values[0] for x in max_values) else I3D_MAX
 
     def make_parameter(name: str, value: list[float]) -> ShaderParameter:
         return ShaderParameter(

--- a/addon/i3dio/ui/shader_picker.py
+++ b/addon/i3dio/ui/shader_picker.py
@@ -8,8 +8,8 @@ from bpy.props import BoolProperty, CollectionProperty, EnumProperty, FloatPrope
 from bpy.types import Panel
 
 from .. import __package__ as base_package
+from ..constants import I3D_MAX
 from ..utility import get_fs_data_path
-from ..xml_i3d import i3d_max
 from .helper_functions import detect_fs_version, humanize_template, is_version_compatible
 from .material_templates import TEMPLATES_GROUP_NAMES
 from .shader_migration_utils import migrate_material_parameters, migrate_material_textures, migrate_variation
@@ -293,7 +293,7 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         description="Amount of light absorbed when passing through the material (higher = darker look)",
         default=i3d_map['light_absorbance']['blender_default'],
         min=0.0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
 
     refraction_bump_scale: FloatProperty(
@@ -301,7 +301,7 @@ class I3DMaterialShader(bpy.types.PropertyGroup):
         description="Intensity of the bump map distortion effect for refraction",
         default=i3d_map['refraction_bump_scale']['blender_default'],
         min=0.0,
-        max=i3d_max,
+        max=I3D_MAX,
     )
 
     refraction_with_ssr_data: BoolProperty(

--- a/addon/i3dio/xml_i3d.py
+++ b/addon/i3dio/xml_i3d.py
@@ -17,10 +17,6 @@ from . import utility
 logger = logging.getLogger(__name__)
 
 XML_Element = ET.Element
-file_ending = '.i3d'
-merge_group_prefix = 'MergedMesh_'
-skinned_mesh_prefix = 'SkinnedMesh_'
-i3d_max = 3.40282e38
 
 
 def parse(*argv, **kwargs) -> ET.ElementTree:


### PR DESCRIPTION
Stacked PR based on #402
Should be merged after #402

- Add shared resource table base class
- Add file resource table for stable file IDs and de-duplication
- Add material resource table for stable material IDs and de-duplication
- Wire file/material tables into `ExportContext`
- Keep file path resolution separate from file registration

Still no connection to the actual export pipeline yet and this does not include any ShapeTable either, mostly because Shape is a lot larger and requires a lot more files