### PR TITLE
Fix castsShadows/receiveShadows="false" never being exported

### DIFF
--- a/addon/i3dio/ui/mesh.py
+++ b/addon/i3dio/ui/mesh.py
@@ -22,8 +22,8 @@ def register(cls):
 @register
 class I3DNodeShapeAttributes(bpy.types.PropertyGroup):
     i3d_map = {
-        'casts_shadows': {'name': 'castsShadows', 'default': False, 'blender_default': True},
-        'receive_shadows': {'name': 'receiveShadows', 'default': False, 'blender_default': True},
+        'casts_shadows': {'name': 'castsShadows', 'default': True, 'blender_default': True},
+        'receive_shadows': {'name': 'receiveShadows', 'default': True, 'blender_default': True},
         'non_renderable': {'name': 'nonRenderable', 'default': False},
         'distance_blending': {'name': 'distanceBlending', 'default': True},
         'rendered_in_viewports': {'name': 'renderedInViewports', 'default': True},


### PR DESCRIPTION
## Problem

In `ui/mesh.py`, `I3DNodeShapeAttributes.i3d_map` declares:

```python
'casts_shadows':   {'name': 'castsShadows',   'default': False, 'blender_default': True},
'receive_shadows': {'name': 'receiveShadows', 'default': False, 'blender_default': True},
```

The Blender property default is `blender_default` (**True**), which matches the engine default (an omitted `castsShadows` casts shadows). But `write_i3d_properties` skips any value equal to the i3d_map `default`:

```python
if utility.isclose_value(value, default):
    continue
```

With `default=False`, that means:
- `casts_shadows = True`  -> written as `castsShadows="true"` (redundant; it's already the engine default)
- `casts_shadows = False` -> **skipped** -> the attribute is never emitted

So a shape explicitly set to **not** cast shadows loses that on export and reverts to casting on the next import. `castsShadows="false"` / `receiveShadows="false"` can never be written.

## Fix

Set `'default': True` for both, matching the engine/Blender default (already recorded in `blender_default`). Now:
- `casts_shadows = True`  -> omitted (engine defaults true -> same result, less redundant output)
- `casts_shadows = False` -> correctly written as `castsShadows="false"`

One-line-per-attribute change; `blender_default` is left in place so the property defaults are untouched.

## Verification

Round-tripping FS25 base-game vehicles (import a `.i3d`, export it back) through the exporter:

| | source `castsShadows="false"` | re-export (before) | re-export (after) |
|---|---|---|---|
| prinoth/leitwolf | 46 shapes | **0** survive | **46** survive |

`receiveShadows` is unchanged where the source has no `="false"` values (the redundant `="true"` is simply no longer written, which is the engine default).

Found while building a Giants-importer -> community-exporter round-trip bridge; this was the only shape attribute that could not round-trip.