### PR TITLE
feat(collision-presets): add preset enum handling

### DIFF
--- a/addon/i3dio/ui/collision_data.py
+++ b/addon/i3dio/ui/collision_data.py
@@ -1,11 +1,13 @@
 from collections import namedtuple
-from pathlib import Path
 
 import bpy
 from bpy.app.handlers import load_post, persistent
 
-from .. import __package__ as base_package
-from .. import xml_i3d
+from .. import addon_logging, xml_i3d
+from ..utility import get_fs_data_path
+from .helper_functions import humanize_template
+
+logger = addon_logging.get_logger("collision_data")
 
 COLLISIONS = {
     'flags': {},  # {name: bit}
@@ -18,6 +20,28 @@ CollisionOutput = namedtuple('CollisionOutput', ['preset', 'group', 'mask', 'wit
 CollisionRule = namedtuple('CollisionRule', ['mask_old', 'outputs'])
 
 
+COLLISION_PRESET_CUSTOM = "CUSTOM"
+_COLLISION_PRESET_ENUM_ITEMS: list[tuple[str, str, str]] = []
+
+
+def rebuild_collision_preset_enum_items() -> None:
+    """Build Blender enum items for collision presets.
+    Kept as a persistent list so dynamic EnumProperty callbacks return stable string references.
+    """
+    _COLLISION_PRESET_ENUM_ITEMS.clear()
+    _COLLISION_PRESET_ENUM_ITEMS.extend(
+        ((COLLISION_PRESET_CUSTOM, "Custom", "Use manually edited collision filter group and mask values"),)
+    )
+
+    _COLLISION_PRESET_ENUM_ITEMS.extend(
+        (name, humanize_template(name), preset.desc or "") for name, preset in sorted(COLLISIONS["presets"].items())
+    )
+
+
+def get_collision_preset_enum_items(self, context):
+    return _COLLISION_PRESET_ENUM_ITEMS
+
+
 def compute_bitmask(flags, flag_dict) -> int:
     return sum(1 << flag_dict[flag] for flag in flags if flag in flag_dict)
 
@@ -28,7 +52,7 @@ def parse_collision_mask_flags(filepath) -> None:
 
     tree = xml_i3d.parse(filepath)
     if tree is None:
-        print(f"Failed to parse {filepath}")
+        logger.error(f"Failed to parse {filepath}")
         return None
 
     root = tree.getroot()
@@ -55,7 +79,7 @@ def parse_collision_mask_flags(filepath) -> None:
                 try:
                     mask_value = int(direct_value, 16)
                 except ValueError:
-                    print(f"Invalid mask value '{direct_value}' in preset '{name}'")
+                    logger.error(f"Invalid mask value '{direct_value}' in preset '{name}'")
                     continue
             else:
                 # If no single value attribute, compute the bitmask from the flags
@@ -73,7 +97,7 @@ def parse_collision_mask_rules(filepath) -> None:
 
     tree = xml_i3d.parse(filepath)
     if tree is None:
-        print(f"Failed to parse {filepath}")
+        logger.error(f"Failed to parse {filepath}")
         return None
 
     root = tree.getroot()
@@ -94,7 +118,7 @@ def parse_collision_mask_rules(filepath) -> None:
                 try:
                     mask_flags = int(mask_value, 16)
                 except ValueError:
-                    print(f"Invalid mask value '{mask_value}' in rule for maskOld '{mask_old}'")
+                    logger.error(f"Invalid mask value '{mask_value}' in rule for maskOld '{mask_old}'")
                     mask_flags = 0
             else:
                 # Parse individual flag names
@@ -107,10 +131,18 @@ def parse_collision_mask_rules(filepath) -> None:
         COLLISIONS['rules'].append(CollisionRule(mask_old, outputs))
 
 
+def clear_collision_cache() -> None:
+    COLLISIONS["flags"].clear()
+    COLLISIONS["presets"].clear()
+    COLLISIONS["rules"].clear()
+    rebuild_collision_preset_enum_items()
+
+
 def populate_collision_cache() -> None:
     """Populate the COLLISIONS cache from XML files"""
-    data_path = Path(bpy.context.preferences.addons[base_package].preferences.fs_data_path)
-    shared_dir = data_path.parent / 'shared'
+    clear_collision_cache()
+
+    shared_dir = get_fs_data_path(as_path=True).parent / 'shared'
     flags_path = shared_dir / 'collisionMaskFlags.xml'
     rules_path = shared_dir / 'collisionMaskConversionRules.xml'
 
@@ -118,12 +150,14 @@ def populate_collision_cache() -> None:
     if flags_path.exists():
         parse_collision_mask_flags(flags_path)
     else:
-        print(f"Collision flags file not found: {flags_path}")
+        logger.error(f"Collision flags file not found: {flags_path}")
 
     if rules_path.exists():
         parse_collision_mask_rules(rules_path)
     else:
-        print(f"Collision rules file not found: {rules_path}")
+        logger.error(f"Collision rules file not found: {rules_path}")
+
+    rebuild_collision_preset_enum_items()
 
 
 def apply_rule_to_mask(rule: CollisionRule, is_trigger: bool) -> dict[str, str]:
@@ -137,7 +171,7 @@ def apply_rule_to_mask(rule: CollisionRule, is_trigger: bool) -> dict[str, str]:
             if flag in flag_map:
                 bitmask |= 1 << flag_map[flag]
             else:
-                print(f"Unknown flag '{flag}'.")
+                logger.error(f"Unknown flag '{flag}'.")
         return bitmask
 
     # Find mathcing output, in maskOld="1073741824" there is 2 outputs, one for trigger and one for non-trigger
@@ -148,7 +182,7 @@ def apply_rule_to_mask(rule: CollisionRule, is_trigger: bool) -> dict[str, str]:
         output = next((o for o in rule.outputs if o.is_trigger is None), None) or rule.outputs[0]
 
     if not output:
-        print("No outputs available in rule. Returning default values.")
+        logger.error("No outputs available in rule. Returning default values.")
         return {'group_hex': 'ff', 'mask_hex': 'ff'}
 
     group_value = 0
@@ -171,7 +205,7 @@ def apply_rule_to_mask(rule: CollisionRule, is_trigger: bool) -> dict[str, str]:
         if flag in COLLISIONS['flags']:
             mask_value &= ~(1 << COLLISIONS['flags'][flag])
         else:
-            print(f"Unknown withoutFlag '{flag}' in rule.")
+            logger.error(f"Unknown withoutFlag '{flag}' in rule.")
 
     return {'group_hex': f"{group_value:x}", 'mask_hex': f"{mask_value:x}"}
 
@@ -189,13 +223,13 @@ def convert_old_collision_masks(dummy) -> None:
             try:
                 old_mask_decimal = int(old_mask_hex, 16)  # Convert to decimal
             except ValueError:
-                print(f"Invalid collision mask '{old_mask_hex}' for object '{obj.name}', skipping.")
+                logger.error(f"Invalid collision mask '{old_mask_hex}' for object '{obj.name}', skipping.")
                 continue
 
             # Get all matching rules for this mask
             rule = rule_lookup.get(old_mask_decimal)
             if not rule:
-                print(f"No rule found for mask '{old_mask_hex}' for object '{obj.name}', skipping.")
+                logger.error(f"No rule found for mask '{old_mask_hex}' for object '{obj.name}', skipping.")
                 continue
 
             is_trigger = getattr(obj.i3d_attributes, 'trigger', False)

--- a/addon/i3dio/ui/helper_functions.py
+++ b/addon/i3dio/ui/helper_functions.py
@@ -89,7 +89,7 @@ def i3d_property(layout, attributes, attribute: str, obj):
 
 def humanize_template(template: str) -> str:
     """Converts a template name to a human-readable format."""
-    return re.sub(r'(?<=[a-z0-9])([A-Z])', r' \1', template).title()
+    return re.sub(r'(?<=[a-z0-9])([A-Z])', r' \1', template.replace('_', ' ')).title()
 
 
 def detect_fs_version(path_str: str) -> str | None:

--- a/addon/i3dio/ui/object.py
+++ b/addon/i3dio/ui/object.py
@@ -15,8 +15,10 @@ from bpy.types import Operator, Panel
 
 from ..constants import I3D_MAX
 from . import light, mesh, presets
-from .collision_data import COLLISIONS
+from .collision_data import COLLISION_PRESET_CUSTOM, COLLISIONS, get_collision_preset_enum_items
 from .helper_functions import i3d_property
+
+_UPDATING_COLLISION_PRESET = "_updating_collision_preset"
 
 classes = []
 
@@ -180,20 +182,50 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         name="Collision", description="Does the object take part in collisions", default=i3d_map['collision']['default']
     )
 
-    def update_collision_preset_name(self, context):
-        """Update the collision filter group and mask based on the selected preset."""
-        preset = COLLISIONS['presets'].get(self.collision_preset_name, {})
-        if preset:
-            self.collision_filter_group = preset.group_hex
-            self.collision_filter_mask = preset.mask_hex
-        else:
-            self.collision_filter_group = self.i3d_map['collision_filter_group']['default']
-            self.collision_filter_mask = self.i3d_map['collision_filter_mask']['default']
+    def _set_collision_filter_values(self, group: str, mask: str) -> None:
+        if self.collision_filter_group != group:
+            self.collision_filter_group = group
 
-    collision_preset_name: StringProperty(
+        if self.collision_filter_mask != mask:
+            self.collision_filter_mask = mask
+
+    def _find_matching_collision_preset(self) -> str:
+        group = self.collision_filter_group.lower().strip()
+        mask = self.collision_filter_mask.lower().strip()
+
+        for name, preset in COLLISIONS["presets"].items():
+            if preset.group_hex.lower() == group and preset.mask_hex.lower() == mask:
+                return name
+
+        return COLLISION_PRESET_CUSTOM
+
+    def update_collision_preset_name(self, context):
+        """Update group/mask when selecting a collision preset."""
+        preset_name = self.collision_preset_name
+        if preset_name == COLLISION_PRESET_CUSTOM:
+            return
+
+        if (preset := COLLISIONS["presets"].get(preset_name)) is None:
+            return
+        self[_UPDATING_COLLISION_PRESET] = True
+        try:
+            self._set_collision_filter_values(preset.group_hex, preset.mask_hex)
+        finally:
+            if _UPDATING_COLLISION_PRESET in self:
+                del self[_UPDATING_COLLISION_PRESET]
+
+    def update_collision_filter_value(self, context):
+        """Set enum to matching preset or Custom when values are edited manually."""
+        if self.get(_UPDATING_COLLISION_PRESET, False):
+            return
+
+        if self.collision_preset_name != (matching_preset := self._find_matching_collision_preset()):
+            self.collision_preset_name = matching_preset
+
+    collision_preset_name: EnumProperty(
         name="Collision Preset Name",
         description="The name of the collision preset to use",
-        default="",
+        items=get_collision_preset_enum_items,
         update=update_collision_preset_name,
     )
 
@@ -201,12 +233,14 @@ class I3DNodeObjectAttributes(bpy.types.PropertyGroup):
         name="Collision Filter Group",
         description="The objects collision filter group as a hexadecimal value",
         default=i3d_map['collision_filter_group']['default'],
+        update=update_collision_filter_value,
     )
 
     collision_filter_mask: StringProperty(
         name="Collision Filter Mask",
         description="The objects collision filter mask as a hexadecimal value",
         default=i3d_map['collision_filter_mask']['default'],
+        update=update_collision_filter_value,
     )
 
     compound: BoolProperty(name="Compound", description="Compound", default=i3d_map['compound']['default'])
@@ -601,58 +635,6 @@ class I3DReferenceData(bpy.types.PropertyGroup):
     )
 
 
-@register
-class I3D_IO_OT_set_collision_preset(bpy.types.Operator):
-    bl_idname = 'i3dio.set_collision_preset'
-    bl_label = 'Set Collision Preset'
-    bl_options = {'INTERNAL', 'UNDO'}
-
-    preset: StringProperty()
-    apply_to_selected: BoolProperty(options={'SKIP_SAVE'})
-
-    @classmethod
-    def description(cls, _context, properties):
-        desc = COLLISIONS['presets'].get(properties.preset, None)
-        if desc and getattr(desc, 'desc', None):
-            return desc.desc
-        return f"Set the collision preset to {properties.preset}"
-
-    def invoke(self, context, event):
-        self.apply_to_selected = event.alt
-        return self.execute(context)
-
-    def execute(self, context):
-        if self.apply_to_selected:
-            for obj in context.selected_objects:
-                if not obj.type == 'MESH':
-                    continue
-                obj.i3d_attributes.collision_preset_name = self.preset
-        else:
-            context.object.i3d_attributes.collision_preset_name = self.preset
-        return {'FINISHED'}
-
-
-@register
-class I3D_IO_MT_collision_presets(bpy.types.Menu):
-    bl_idname = "I3D_IO_MT_collision_presets"
-    bl_label = "Collision Presets"
-
-    def draw(self, _context):
-        layout = self.layout
-        presets = list(COLLISIONS['presets'].keys())
-
-        if not presets:
-            layout.label(text="No Presets Available")
-            return
-
-        grid = layout.grid_flow(columns=2, even_columns=True, even_rows=True)
-        for preset in presets:
-            text = preset.title().replace('_', ' ')
-            grid.operator(I3D_IO_OT_set_collision_preset.bl_idname, text=text).preset = preset
-        layout.separator()
-        layout.operator(I3D_IO_OT_set_collision_preset.bl_idname, text="None").preset = "NONE"
-
-
 SPLIT_TYPE_PRESETS = {
     "Spruce": {'split_type': 1, 'support_wood_harvester': True},
     "Pine": {'split_type': 2, 'support_wood_harvester': True},
@@ -785,6 +767,7 @@ def draw_rigid_body_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.t
     unset_props = (
         'compound',
         'collision',
+        'collision_preset_name',
         'collision_filter_group',
         'collision_filter_mask',
         'trigger',
@@ -820,9 +803,8 @@ def draw_rigid_body_attributes(layout: bpy.types.UILayout, i3d_attributes: bpy.t
 
         col_filter_header, col_filter_panel = panel.panel('i3d_collision_filter', default_closed=False)
         col_filter_header.label(text="Collision Filter")
-        col_filter_header.emboss = 'NONE'
-        col_filter_header.menu(I3D_IO_MT_collision_presets.bl_idname, icon='PRESET', text="")
         if col_filter_panel:
+            col_filter_panel.prop(i3d_attributes, 'collision_preset_name', text="Preset", icon='PRESET')
             row = col_filter_panel.row()
             row.prop(i3d_attributes, 'collision_filter_group')
             op = row.operator('i3dio.bit_mask_editor', text="", icon='THREE_DOTS')


### PR DESCRIPTION
This PR supersedes #404 by DaVaR after a follow-up discussion about the implementation.

The initial PR introduced the preset enum workflow. This version builds on that by caching the enum items, removing the old menu/operator path, and improving the preset/manual value sync.